### PR TITLE
Feat/#13

### DIFF
--- a/components/layout/Sidebar.tsx
+++ b/components/layout/Sidebar.tsx
@@ -38,6 +38,19 @@ export default function Sidebar({ isOpen, onClose, authSection }: SidebarProps) 
     }, [pathname, isOpen])
 
     useEffect(() => {
+        if (!isOpen) {
+            return
+        }
+
+        const previousOverflow = document.body.style.overflow
+        document.body.style.overflow = "hidden"
+
+        return () => {
+            document.body.style.overflow = previousOverflow
+        }
+    }, [isOpen])
+
+    useEffect(() => {
         if (pathname !== "/") {
             return
         }
@@ -129,11 +142,11 @@ export default function Sidebar({ isOpen, onClose, authSection }: SidebarProps) 
                 type="button"
                 aria-label="Close menu"
                 onClick={onClose}
-                className={`fixed inset-0 z-40 cursor-default bg-black/20 transition-opacity duration-500 ${isOpen ? "opacity-100" : "pointer-events-none opacity-0"
+                className={`fixed left-0 top-0 z-40 h-dvh w-screen cursor-default bg-black/20 transition-opacity duration-500 ${isOpen ? "opacity-100" : "pointer-events-none opacity-0"
                     }`}
             />
             <aside
-                className={`fixed right-0 top-0 z-50 h-full w-[412px] bg-[#303136] shadow-xl transition-transform duration-500 ease-out ${isOpen ? "translate-x-0" : "translate-x-full"
+                className={`fixed right-0 top-0 z-50 h-dvh w-[min(412px,100vw)] bg-[#303136] shadow-xl transition-transform duration-500 ease-out ${isOpen ? "translate-x-0" : "translate-x-full"
                     }`}
                 role="dialog"
                 aria-modal="true"

--- a/features/public/api.ts
+++ b/features/public/api.ts
@@ -1,6 +1,8 @@
 import type {
     CheckAvailabilityResponse,
     EmailActionResponse,
+    FindIdVerifyRequest,
+    FindIdVerifyResponse,
     LoginRequest,
     LoginResponse,
     LogoutResponse,
@@ -8,6 +10,7 @@ import type {
     RegisterPayload,
     RegisterRequest,
     RegisterResponse,
+    ResetPasswordVerifyRequest,
     RefreshTokenResponse,
     SendEmailCodeRequest,
     VerifyEmailCodeRequest,
@@ -78,34 +81,49 @@ export async function verifyEmailCode(payload: VerifyEmailCodeRequest): Promise<
     return response.data
 }
 
+export async function findIdByEmailVerify(payload: FindIdVerifyRequest): Promise<FindIdVerifyResponse> {
+    const response = await apiClient.post<FindIdVerifyResponse>("/auth/email/find-id/verify", payload)
+    return response.data
+}
+
+export async function resetPasswordByEmailVerify(payload: ResetPasswordVerifyRequest): Promise<EmailActionResponse> {
+    const response = await apiClient.post<EmailActionResponse>("/auth/email/reset-password/verify", payload)
+    return response.data
+}
+
 export async function register(payload: RegisterPayload): Promise<RegisterResponse> {
+    const requestBody: RegisterRequest = {
+        loginId: payload.loginId,
+        email: payload.email,
+        password: payload.password,
+        name: payload.name,
+        department: payload.department,
+        studentNo: payload.studentNo,
+        grade: payload.grade,
+        enrollment: payload.enrollment,
+        birthDate: payload.birthDate,
+        phone: payload.phone,
+    }
+
     if (payload.profileImage) {
-        const formData = new FormData()
-        formData.append("loginId", payload.loginId)
-        formData.append("email", payload.email)
-        formData.append("password", payload.password)
-        formData.append("name", payload.name)
-        formData.append("department", payload.department)
-        formData.append("studentNo", payload.studentNo)
-        formData.append("grade", String(payload.grade))
-        formData.append("enrollment", payload.enrollment)
-        formData.append("birthDate", payload.birthDate)
-        formData.append("phone", payload.phone)
-        formData.append("profileImage", payload.profileImage)
-        const debugEntries = Array.from(formData.entries()).map(([key, value]) => {
-            if (key === "password") {
-                return [key, `***masked*** (${String(value).length} chars)`]
-            }
-            if (value instanceof File) {
-                return [key, { name: value.name, type: value.type, size: value.size }]
-            }
-            return [key, value]
+        const multipartBody = {
+            ...requestBody,
+            profileImage: payload.profileImage,
+        }
+
+        console.log("[register] request mode: multipart/form-data (auto)")
+        console.log("[register] request payload:", {
+            ...requestBody,
+            password: `***masked*** (${requestBody.password.length} chars)`,
+            profileImage: {
+                name: payload.profileImage.name,
+                type: payload.profileImage.type,
+                size: payload.profileImage.size,
+            },
         })
-        console.log("[register] request mode: multipart/form-data")
-        console.log("[register] request payload:", Object.fromEntries(debugEntries))
 
         try {
-            const response = await apiClient.post<RegisterResponse>("/auth/register", formData)
+            const response = await apiClient.postForm<RegisterResponse>("/auth/register", multipartBody)
             return response.data
         } catch (error) {
             if (isAxiosError(error)) {
@@ -120,18 +138,6 @@ export async function register(payload: RegisterPayload): Promise<RegisterRespon
         }
     }
 
-    const requestBody: RegisterRequest = {
-        loginId: payload.loginId,
-        email: payload.email,
-        password: payload.password,
-        name: payload.name,
-        department: payload.department,
-        studentNo: payload.studentNo,
-        grade: payload.grade,
-        enrollment: payload.enrollment,
-        birthDate: payload.birthDate,
-        phone: payload.phone,
-    }
     console.log("[register] request mode: application/json")
     console.log("[register] request payload:", {
         ...requestBody,
@@ -139,11 +145,7 @@ export async function register(payload: RegisterPayload): Promise<RegisterRespon
     })
 
     try {
-        const response = await apiClient.post<RegisterResponse>("/auth/register", requestBody, {
-            headers: {
-                "Content-Type": "application/json",
-            },
-        })
+        const response = await apiClient.post<RegisterResponse>("/auth/register", requestBody)
         return response.data
     } catch (error) {
         if (isAxiosError(error)) {

--- a/features/public/auth/FindId.tsx
+++ b/features/public/auth/FindId.tsx
@@ -1,15 +1,140 @@
+"use client"
+
+import Image from "next/image"
 import Link from "next/link"
+import { FormEvent, useState } from "react"
+import { findIdByEmailVerify, sendEmailCode } from "@/features/public/api"
 
 export default function FindIdFeature() {
+    const [email, setEmail] = useState("")
+    const [code, setCode] = useState("")
+    const [foundLoginId, setFoundLoginId] = useState("")
+    const [isSendingCode, setIsSendingCode] = useState(false)
+    const [isVerifying, setIsVerifying] = useState(false)
+    const [message, setMessage] = useState("")
+    const [errorMessage, setErrorMessage] = useState("")
+
+    const handleSendCode = async () => {
+        if (!email) {
+            setErrorMessage("이메일을 먼저 입력해주세요.")
+            return
+        }
+
+        setErrorMessage("")
+        setMessage("")
+        setIsSendingCode(true)
+        try {
+            const result = await sendEmailCode({
+                email,
+                purpose: "FIND_ID",
+            })
+            setMessage(result.message || "인증번호를 전송했습니다.")
+        } catch {
+            setErrorMessage("인증번호 전송에 실패했습니다.")
+        } finally {
+            setIsSendingCode(false)
+        }
+    }
+
+    const handleVerify = async (event: FormEvent<HTMLFormElement>) => {
+        event.preventDefault()
+        setErrorMessage("")
+        setMessage("")
+        setFoundLoginId("")
+        setIsVerifying(true)
+
+        try {
+            const result = await findIdByEmailVerify({ email, code })
+            setFoundLoginId(result.loginId)
+        } catch {
+            setErrorMessage("인증번호 확인에 실패했습니다.")
+        } finally {
+            setIsVerifying(false)
+        }
+    }
+
     return (
-        <section className="mx-auto mt-27 w-full max-w-4xl rounded-t-[50px] bg-[linear-gradient(180deg,#484D5A_-23.29%,#303136_46.27%)] px-11 pb-12 pt-11">
-            <h1 className="mb-6 text-3xl font-bold text-foreground">아이디 찾기</h1>
-            <p className="text-sm text-gray-200">아이디 찾기 화면입니다. 필요한 입력 폼을 여기에 추가하면 됩니다.</p>
-            <div className="mt-8">
-                <Link href="/auth" className="inline-flex h-10 items-center rounded bg-[#4b9cff] px-4 text-sm font-semibold text-white">
-                    로그인으로 돌아가기
-                </Link>
-            </div>
-        </section>
+        <div className="relative mx-auto mt-27 w-full max-w-4xl pt-28">
+            <Image
+                className="pointer-events-none absolute left-1/2 top-20 z-0 h-[108px] w-[82px] -translate-x-1/2 -translate-y-1/2 md:h-[216px] md:w-[164px]"
+                src="/images/authLion.webp"
+                alt="authLion"
+                width={164}
+                height={216}
+                priority
+            />
+
+            <section className="relative z-10 min-h-[calc(100vh-220px)] w-full rounded-t-[56px] bg-[linear-gradient(180deg,#484D5A_-23.29%,#303136_46.27%)] px-4 pb-9 pt-16 md:rounded-t-[225px]">
+                <div className="mx-auto max-w-[520px]">
+                    <div className="mb-6 flex flex-col items-center">
+                        <div className="mb-3 h-[72px] w-[72px] overflow-hidden rounded-full bg-white p-2">
+                            <Image src="/images/syuLikelion.webp" alt="logo" width={56} height={56} />
+                        </div>
+                        <h1 className="text-lg font-bold text-main-3 md:text-xl">아이디 찾기</h1>
+                    </div>
+
+                    {foundLoginId ? (
+                        <div className="rounded-2xl bg-[#3d4456] px-6 py-8 text-center">
+                            <p className="mb-3 text-sm text-gray-3">회원님의 아이디입니다.</p>
+                            <p className="mb-4 break-all text-lg font-bold text-foreground">{foundLoginId}</p>
+                            <Link
+                                href="/auth"
+                                className="inline-flex h-12.5 items-center rounded-[14px] bg-main-1 px-8 text-lg font-bold text-white md:h-20 md:rounded-2xl md:text-xl"
+                            >
+                                LOGIN
+                            </Link>
+                        </div>
+                    ) : (
+                        <form onSubmit={handleVerify} className="space-y-4">
+                            <label className="block">
+                                <span className="mb-2 block text-lg font-bold text-foreground md:text-xl">E-MAIL</span>
+                                <div className="flex gap-2">
+                                    <input
+                                        value={email}
+                                        onChange={(event) => setEmail(event.target.value)}
+                                        type="email"
+                                        required
+                                        placeholder="이메일을 입력해주세요."
+                                        className="h-12.5 w-full rounded-[14px] border border-[#484d5a] bg-gray-6 px-6 text-base text-gray-4 outline-none md:h-20 md:rounded-2xl md:text-xl"
+                                    />
+                                    <button
+                                        type="button"
+                                        onClick={handleSendCode}
+                                        disabled={isSendingCode}
+                                        className="h-12.5 w-[87px] shrink-0 rounded-[14px] bg-main-1 px-2 text-sm font-bold text-white disabled:opacity-60 md:h-20 md:w-[146px] md:rounded-2xl md:px-3 md:text-base"
+                                    >
+                                        {isSendingCode ? "전송 중" : "인증번호 전송"}
+                                    </button>
+                                </div>
+                            </label>
+
+                            <label className="block">
+                                <span className="mb-2 block text-lg font-bold text-foreground md:text-xl">인증번호</span>
+                                <input
+                                    value={code}
+                                    onChange={(event) => setCode(event.target.value)}
+                                    required
+                                    placeholder="인증번호를 입력해주세요."
+                                    className="h-12.5 w-full rounded-[14px] border border-[#484d5a] bg-gray-6 px-6 text-base text-gray-4 outline-none md:h-20 md:rounded-2xl md:text-xl"
+                                />
+                            </label>
+
+                            {message ? <p className="text-xs text-[#7ee787]">{message}</p> : null}
+                            {errorMessage ? <p className="text-xs text-[#ff7b7b]">{errorMessage}</p> : null}
+
+                            <div className="pt-2 text-center">
+                                <button
+                                    type="submit"
+                                    disabled={isVerifying}
+                                    className="inline-flex h-12.5 items-center rounded-[14px] bg-main-1 px-8 text-lg font-bold text-white disabled:opacity-60 md:h-20 md:rounded-2xl md:text-xl"
+                                >
+                                    {isVerifying ? "확인 중" : "아이디 찾기"}
+                                </button>
+                            </div>
+                        </form>
+                    )}
+                </div>
+            </section>
+        </div>
     )
 }

--- a/features/public/auth/FindPw.tsx
+++ b/features/public/auth/FindPw.tsx
@@ -1,15 +1,238 @@
-import Link from "next/link"
+"use client"
+
+import Image from "next/image"
+import { FormEvent, useEffect, useMemo, useState } from "react"
+import { useRouter } from "next/navigation"
+import { resetPasswordByEmailVerify, sendEmailCode } from "@/features/public/api"
+
+type Step = 1 | 2
 
 export default function FindPwFeature() {
+    const router = useRouter()
+    const [step, setStep] = useState<Step>(1)
+    const [loginId, setLoginId] = useState("")
+    const [email, setEmail] = useState("")
+    const [code, setCode] = useState("")
+    const [newPassword, setNewPassword] = useState("")
+    const [isSendingCode, setIsSendingCode] = useState(false)
+    const [isSubmitting, setIsSubmitting] = useState(false)
+    const [isSuccessPopupVisible, setIsSuccessPopupVisible] = useState(false)
+    const [message, setMessage] = useState("")
+    const [errorMessage, setErrorMessage] = useState("")
+
+    const passwordRule = /^(?=.*[a-zA-Z])(?=.*\d)(?=.*[^a-zA-Z0-9]).{8,20}$/
+    const isPasswordValid = passwordRule.test(newPassword)
+    const canGoNext = loginId.trim().length > 0 && email.trim().length > 0 && code.trim().length > 0
+
+    const canSubmit = useMemo(() => canGoNext && isPasswordValid, [canGoNext, isPasswordValid])
+
+    useEffect(() => {
+        if (!isSuccessPopupVisible) {
+            return
+        }
+
+        const completeTimer = window.setTimeout(() => {
+            setIsSuccessPopupVisible(false)
+            router.replace("/auth")
+        }, 1400)
+
+        return () => {
+            window.clearTimeout(completeTimer)
+        }
+    }, [isSuccessPopupVisible, router])
+
+    const handleSendCode = async () => {
+        if (!email) {
+            setErrorMessage("이메일을 먼저 입력해주세요.")
+            return
+        }
+
+        setErrorMessage("")
+        setMessage("")
+        setIsSendingCode(true)
+
+        try {
+            const result = await sendEmailCode({
+                email,
+                purpose: "RESET_PASSWORD",
+                loginId: loginId || undefined,
+            })
+            setMessage(result.message || "인증번호를 전송했습니다.")
+        } catch {
+            setErrorMessage("인증번호 전송에 실패했습니다.")
+        } finally {
+            setIsSendingCode(false)
+        }
+    }
+
+    const handleNext = (event: FormEvent<HTMLFormElement>) => {
+        event.preventDefault()
+        setErrorMessage("")
+        setMessage("")
+
+        if (!canGoNext) {
+            setErrorMessage("ID, E-MAIL, 인증번호를 모두 입력해주세요.")
+            return
+        }
+
+        setStep(2)
+    }
+
+    const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+        event.preventDefault()
+        setErrorMessage("")
+        setMessage("")
+
+        if (!isPasswordValid) {
+            setErrorMessage("비밀번호는 8~20자 영문, 숫자, 특수문자를 포함해야 합니다.")
+            return
+        }
+
+        setIsSubmitting(true)
+        try {
+            const result = await resetPasswordByEmailVerify({
+                loginId,
+                email,
+                code,
+                newPassword,
+            })
+
+            if (!result.ok) {
+                setErrorMessage(result.message || "비밀번호 재설정에 실패했습니다.")
+                return
+            }
+
+            setMessage(result.message || "비밀번호가 재설정되었습니다.")
+            setIsSuccessPopupVisible(true)
+        } catch {
+            setErrorMessage("비밀번호 재설정에 실패했습니다.")
+        } finally {
+            setIsSubmitting(false)
+        }
+    }
+
     return (
-        <section className="mx-auto mt-27 w-full max-w-4xl rounded-t-[50px] bg-[linear-gradient(180deg,#484D5A_-23.29%,#303136_46.27%)] px-11 pb-12 pt-11">
-            <h1 className="mb-6 text-3xl font-bold text-foreground">비밀번호 찾기</h1>
-            <p className="text-sm text-gray-200">비밀번호 찾기 화면입니다. 필요한 입력 폼을 여기에 추가하면 됩니다.</p>
-            <div className="mt-8">
-                <Link href="/auth" className="inline-flex h-10 items-center rounded bg-[#4b9cff] px-4 text-sm font-semibold text-white">
-                    로그인으로 돌아가기
-                </Link>
-            </div>
-        </section>
+        <div className="relative mx-auto mt-27 w-full max-w-4xl pt-28">
+            <Image
+                className="pointer-events-none absolute left-1/2 top-20 z-0 h-[108px] w-[82px] -translate-x-1/2 -translate-y-1/2 md:h-[216px] md:w-[164px]"
+                src="/images/authLion.webp"
+                alt="authLion"
+                width={164}
+                height={216}
+                priority
+            />
+
+            <section className="relative z-10 min-h-[calc(100vh-220px)] w-full rounded-t-[56px] bg-[linear-gradient(180deg,#484D5A_-23.29%,#303136_46.27%)] px-4 pb-9 pt-16 md:rounded-t-[225px]">
+                <div className="mx-auto max-w-[520px]">
+                    <div className="mb-6 flex flex-col items-center">
+                        <div className="mb-3 h-[72px] w-[72px] overflow-hidden rounded-full bg-white p-2">
+                            <Image src="/images/syuLikelion.webp" alt="logo" width={56} height={56} />
+                        </div>
+                        <h1 className="text-lg font-bold text-main-3 md:text-xl">비밀번호 재설정</h1>
+                    </div>
+
+                    {step === 1 ? (
+                        <form onSubmit={handleNext} className="space-y-4">
+                            <label className="block">
+                                <span className="mb-2 block text-lg font-bold text-foreground md:text-xl">ID</span>
+                                <input
+                                    value={loginId}
+                                    onChange={(event) => setLoginId(event.target.value)}
+                                    required
+                                    placeholder="아이디를 입력해주세요."
+                                    className="h-12.5 w-full rounded-[14px] border border-[#484d5a] bg-gray-6 px-6 text-base text-gray-4 outline-none md:h-20 md:rounded-2xl md:text-xl"
+                                />
+                            </label>
+
+                            <label className="block">
+                                <span className="mb-2 block text-lg font-bold text-foreground md:text-xl">E-MAIL</span>
+                                <div className="flex gap-2">
+                                    <input
+                                        value={email}
+                                        onChange={(event) => setEmail(event.target.value)}
+                                        type="email"
+                                        required
+                                        placeholder="이메일을 입력해주세요."
+                                        className="h-12.5 w-full rounded-[14px] border border-[#484d5a] bg-gray-6 px-6 text-base text-gray-4 outline-none md:h-20 md:rounded-2xl md:text-xl"
+                                    />
+                                    <button
+                                        type="button"
+                                        onClick={handleSendCode}
+                                        disabled={isSendingCode}
+                                        className="h-12.5 w-[87px] shrink-0 rounded-[14px] bg-main-1 px-2 text-sm font-bold text-white disabled:opacity-60 md:h-20 md:w-[146px] md:rounded-2xl md:px-3 md:text-base"
+                                    >
+                                        {isSendingCode ? "전송 중" : "인증번호 전송"}
+                                    </button>
+                                </div>
+                            </label>
+
+                            <label className="block">
+                                <span className="mb-2 block text-lg font-bold text-foreground md:text-xl">인증번호</span>
+                                <input
+                                    value={code}
+                                    onChange={(event) => setCode(event.target.value)}
+                                    required
+                                    placeholder="인증번호를 입력해주세요."
+                                    className="h-12.5 w-full rounded-[14px] border border-[#484d5a] bg-gray-6 px-6 text-base text-gray-4 outline-none md:h-20 md:rounded-2xl md:text-xl"
+                                />
+                            </label>
+
+                            {message ? <p className="text-xs text-[#7ee787]">{message}</p> : null}
+                            {errorMessage ? <p className="text-xs text-[#ff7b7b]">{errorMessage}</p> : null}
+
+                            <div className="pt-2 text-center">
+                                <button
+                                    type="submit"
+                                    disabled={!canGoNext}
+                                    className="inline-flex h-12.5 items-center rounded-[14px] bg-main-1 px-8 text-lg font-bold text-white disabled:opacity-60 md:h-20 md:rounded-2xl md:text-xl"
+                                >
+                                    다음
+                                </button>
+                            </div>
+                        </form>
+                    ) : (
+                        <form onSubmit={handleSubmit} className="space-y-4">
+                            <label className="block">
+                                <span className="mb-2 block text-lg font-bold text-foreground md:text-xl">NEW PASSWORD</span>
+                                <input
+                                    value={newPassword}
+                                    onChange={(event) => setNewPassword(event.target.value)}
+                                    type="password"
+                                    required
+                                    placeholder="새 비밀번호를 입력해주세요."
+                                    className="h-12.5 w-full rounded-[14px] border border-[#484d5a] bg-gray-6 px-6 text-base text-gray-4 outline-none md:h-20 md:rounded-2xl md:text-xl"
+                                />
+                            </label>
+                            <p className="text-xs text-gray-400">*8~20자 영문, 숫자, 특수문자를 포함해야 합니다.</p>
+                            {newPassword.length > 0 ? (
+                                <p className={`text-xs ${isPasswordValid ? "text-[#7ee787]" : "text-[#ff7b7b]"}`}>
+                                    {isPasswordValid
+                                        ? "*사용 가능한 비밀번호 형식입니다."
+                                        : "*비밀번호 형식이 올바르지 않습니다."}
+                                </p>
+                            ) : null}
+
+                            <div className="pt-2 text-center">
+                                <button
+                                    type="submit"
+                                    disabled={!canSubmit || isSubmitting}
+                                    className="inline-flex h-12.5 items-center rounded-[14px] bg-main-1 px-8 text-lg font-bold text-white disabled:opacity-60 md:h-20 md:rounded-2xl md:text-xl"
+                                >
+                                    {isSubmitting ? "처리 중" : "비밀번호 재설정"}
+                                </button>
+                            </div>
+                        </form>
+                    )}
+                </div>
+            </section>
+
+            {isSuccessPopupVisible ? (
+                <div className="fixed inset-0 z-[120] flex items-center justify-center bg-black/45 px-4">
+                    <div className="w-full max-w-[320px] rounded-2xl bg-white p-6 text-center shadow-2xl">
+                        <p className="text-base font-bold text-[#303136]">비밀번호가 성공적으로 변경되었습니다.</p>
+                    </div>
+                </div>
+            ) : null}
+        </div>
     )
 }

--- a/features/public/auth/LoginPage.tsx
+++ b/features/public/auth/LoginPage.tsx
@@ -12,6 +12,8 @@ export default function LoginPageFeature() {
     const [password, setPassword] = useState("")
     const [errorMessage, setErrorMessage] = useState("")
     const [isSubmitting, setIsSubmitting] = useState(false)
+    const authInputClass =
+        "h-12.5 w-80.75 rounded-[14px] border border-[#484d5a] bg-gray-6 px-6 text-base text-gray-4 outline-none md:h-20 md:w-122 md:rounded-2xl md:text-xl"
 
     const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
         event.preventDefault()
@@ -32,7 +34,7 @@ export default function LoginPageFeature() {
     return (
         <div className="relative mx-auto mt-27 w-full max-w-4xl pt-28">
             <Image
-                className="pointer-events-none absolute left-1/2 top-20 z-0 -translate-x-1/2 -translate-y-1/2"
+                className="pointer-events-none absolute left-1/2 top-20 z-0 h-[108px] w-[82px] -translate-x-1/2 -translate-y-1/2 md:h-[216px] md:w-[164px]"
                 src="/images/authLion.webp"
                 alt="authLion"
                 width={164}
@@ -40,66 +42,53 @@ export default function LoginPageFeature() {
                 priority
             />
 
-            <section className="relative h-[calc(100vh-220px)] z-10 rounded-t-[225px] bg-[linear-gradient(180deg,#484D5A_-23.29%,#303136_46.27%)] px-4 pt-16 pb-9">
-                <form onSubmit={handleSubmit} className="space-y-4 flex flex-col justify-center items-center">
-                    <div className="w-52 h-52 flex justify-center items-center justify-self-center bg-foreground rounded-full p-6">
+            <section className="relative z-10 h-[calc(100vh-220px)] w-full rounded-t-[56px] bg-[linear-gradient(180deg,#484D5A_-23.29%,#303136_46.27%)] px-4 pb-9 pt-16 md:rounded-t-[225px]">
+                <form onSubmit={handleSubmit} className="flex flex-col items-center justify-center space-y-4">
+                    <div className="flex h-[61px] w-[61px] items-center justify-center justify-self-center rounded-full bg-foreground p-1 md:h-52 md:w-52 md:p-6">
                         <Image
                             src="/images/syuLikelion.webp"
                             alt="LIKELION 14TH"
                             width={197}
                             height={197}
+                            className="h-[61px] w-[61px] md:h-[197px] md:w-[197px]"
                             priority
                         />
                     </div>
 
                     <label className="block">
-                        <span className="mb-2 block text-xl font-bold text-foreground">ID</span>
+                        <span className="mb-2 block text-lg font-bold text-foreground md:text-xl">ID</span>
                         <input
                             type="text"
                             value={loginId}
                             onChange={(event) => setLoginId(event.target.value)}
                             required
                             placeholder="아이디를 입력해 주세요."
-                            className="h-20 w-[488px] rounded-2xl border border-[#484d5a] bg-gray-6 text-gray-4 px-6 text-xl outline-none"
+                            className={authInputClass}
                         />
                     </label>
 
                     <label className="block">
-                        <span className="mb-2 block text-xl font-bold text-foreground">PASSWORD</span>
+                        <span className="mb-2 block text-lg font-bold text-foreground md:text-xl">PASSWORD</span>
                         <input
                             type="password"
                             value={password}
                             onChange={(event) => setPassword(event.target.value)}
                             required
                             placeholder="비밀번호를 입력해 주세요."
-                            className="h-20 w-[488px] rounded-2xl border border-[#484d5a] bg-gray-6 text-gray-4 px-6 text-xl outline-none"
+                            className={authInputClass}
                         />
                     </label>
 
                     {errorMessage ? <p className="text-sm text-[#ff9b43]">{errorMessage}</p> : null}
 
-                    <div className="flex items-center justify-center gap-2 text-base font-normal text-gray-2">
-                        <Link
-                            href="/findid">
-                            아이디 찾기
-                        </Link>
-                        |
-                        <Link
-                            href="/findpw">
-                            비밀번호 재설정
-                        </Link>
-                        |
-                        <Link
-                            href="/signup"
-                        >
-                            회원가입
-                        </Link>
+                    <div className="flex items-center justify-center gap-2 text-sm font-normal text-gray-2 md:text-base">
+                        <Link href="/findid">아이디 찾기</Link>|<Link href="/findpw">비밀번호 재설정</Link>|<Link href="/signup">회원가입</Link>
                     </div>
 
                     <button
                         type="submit"
                         disabled={isSubmitting}
-                        className="inline-flex h-11 w-auto mt-8 rounded-full items-center justify-center bg-[#0b7de2] text-2xl font-bold text-white px-10 py-3 disabled:opacity-50"
+                        className="mt-8 inline-flex h-[50px] w-auto items-center justify-center rounded-[14px] bg-[#0b7de2] px-10 py-3 text-lg font-bold text-white disabled:opacity-50 md:h-11 md:rounded-full md:text-2xl"
                     >
                         {isSubmitting ? "WAIT..." : "LOGIN"}
                     </button>

--- a/features/public/type.ts
+++ b/features/public/type.ts
@@ -77,6 +77,22 @@ export type EmailActionResponse = {
     message: string
 }
 
+export type FindIdVerifyRequest = {
+    email: string
+    code: string
+}
+
+export type FindIdVerifyResponse = {
+    loginId: string
+}
+
+export type ResetPasswordVerifyRequest = {
+    loginId: string
+    email: string
+    code: string
+    newPassword: string
+}
+
 export type RegisterRequest = {
     loginId: string
     email: string


### PR DESCRIPTION
## 📎 관련 이슈
Closes #13


## 📝 작업 내용
- 회원가입 요청에서 이미지 첨부 시 실패하던 문제를 수정했습니다. 이미지가 있을 때 `postForm` 기반으로 `multipart/form-data`를 자동 처리하고, JSON 요청에서도 `Content-Type` 수동 지정 없이 전송되도록 정리
- 아이디/비밀번호 찾기 API 타입 및 호출 함수를 추가하고, `FindId`/`FindPw` 화면을 실제 동작 가능한 인증번호 전송·검증 플로우로 구현
- 로그인 페이지 입력 스타일을 기준으로 비밀번호 및 ID/PW 찾기 입력 UI를 통일하고, 관련 문구를 한글로 정비했습니다.
- 모바일에서 사이드바 오버레이가 화면(뷰포트) 범위만 가리도록 `h-dvh`/`w-screen` 기준으로 수정하고, 사이드바 오픈 시 배경 스크롤 잠금 처리를 추가

## 체크리스트
- [ ] 포메팅이 적용되었습니다.

## 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)

## 💬 비고