### PR TITLE
Feat/#20

### DIFF
--- a/components/layout/Header.tsx
+++ b/components/layout/Header.tsx
@@ -51,6 +51,7 @@ export default function Header() {
     const authSection = me ? (
         <UserInfo
             name={me.homepage.name}
+            profileImageUrl={me.homepage.profileImage?.url ?? me.homepage.profileImageUrl ?? undefined}
             generation={me.roles[0]?.generation}
             role={me.roles[0]?.level}
             track={me.roles[0]?.track}

--- a/components/layout/Login.tsx
+++ b/components/layout/Login.tsx
@@ -6,7 +6,7 @@ export default function Login() {
     return (
         <Link
             href="/auth"
-            className="px-5 py-3.5 inline-flex items-center rounded-full bg-white text-xl font-bold text-main-1"
+            className="inline-flex items-center rounded-full bg-white px-5 py-3.5 text-xl font-bold text-main-1"
         >
             로그인 / 회원가입
         </Link>

--- a/components/layout/Sidebar.tsx
+++ b/components/layout/Sidebar.tsx
@@ -142,17 +142,31 @@ export default function Sidebar({ isOpen, onClose, authSection }: SidebarProps) 
                 type="button"
                 aria-label="Close menu"
                 onClick={onClose}
-                className={`fixed left-0 top-0 z-40 h-dvh w-screen cursor-default bg-black/20 transition-opacity duration-500 ${isOpen ? "opacity-100" : "pointer-events-none opacity-0"
+                className={`fixed left-0 top-0 z-40 h-dvh w-screen cursor-default bg-black/35 backdrop-blur-[3px] transition-opacity duration-500 md:bg-black/20 md:backdrop-blur-0 ${isOpen ? "opacity-100" : "pointer-events-none opacity-0"
                     }`}
             />
             <aside
-                className={`fixed right-0 top-0 z-50 h-dvh w-[min(412px,100vw)] bg-[#303136] shadow-xl transition-transform duration-500 ease-out ${isOpen ? "translate-x-0" : "translate-x-full"
+                className={`fixed right-0 top-0 z-50 h-dvh w-[min(320px,78vw)] bg-[#30333c] shadow-xl transition-transform duration-500 ease-out md:w-[min(412px,100vw)] md:bg-[#303136] ${isOpen ? "translate-x-0" : "translate-x-full"
                     }`}
                 role="dialog"
                 aria-modal="true"
                 aria-hidden={!isOpen}
             >
-                <div className="flex h-16 items-center justify-end px-4">
+                <button
+                    type="button"
+                    aria-label="Close menu"
+                    onClick={onClose}
+                    className="absolute right-3 top-3 z-20 inline-flex h-11 w-11 items-center justify-center rounded-md border border-none cursor-pointer md:hidden"
+                >
+                    <Image
+                        src="/images/closeButton.webp"
+                        alt=""
+                        width={36}
+                        height={36}
+                        priority
+                    />
+                </button>
+                <div className="hidden h-16 items-center justify-end px-4 md:flex">
                     <button
                         type="button"
                         aria-label="Close menu"
@@ -168,20 +182,20 @@ export default function Sidebar({ isOpen, onClose, authSection }: SidebarProps) 
                         />
                     </button>
                 </div>
-                <div className="p-4" onClickCapture={handleActionClickCapture}>
+                <div className="px-4 pb-6 pt-18 md:p-4" onClickCapture={handleActionClickCapture}>
                     <div>{authSection}</div>
-                    <ul className="mt-8">
+                    <ul className="mt-7 md:mt-8">
                         {menus.map((menu, index) => {
                             const isActive = index === activeIndex
                             const marginTop =
-                                index === 0 ? "mt-0" : index - 1 === activeIndex || isActive ? "mt-[38px]" : "mt-[28px]"
+                                index === 0 ? "mt-0" : index - 1 === activeIndex || isActive ? "mt-7 md:mt-[38px]" : "mt-5 md:mt-[28px]"
 
                             return (
                                 <li key={menu.href} className={marginTop}>
                                     <Link
                                         href={menu.href}
                                         onClick={(event) => handleMenuClick(event, menu.href)}
-                                        className={`leading-none ${isActive ? "text-[32px] font-bold text-foreground" : "text-[24px] font-medium text-gray-3"}`}
+                                        className={`leading-none ${isActive ? "text-[38px] font-bold text-foreground md:text-[32px]" : "text-[30px] font-medium text-gray-3 md:text-[24px]"}`}
                                     >
                                         {menu.label}
                                     </Link>

--- a/components/layout/UserInfo.tsx
+++ b/components/layout/UserInfo.tsx
@@ -6,7 +6,8 @@ import { logout } from "@/features/public/api"
 
 type UserInfoProps = {
     name: string
-    generation?: number
+    profileImageUrl?: string
+    generation?: number | null
     role?: string
     track?: string
     onLoggedOut?: () => void
@@ -31,6 +32,7 @@ function getRoleLabel(role?: string): string {
 
 export default function UserInfo({
     name,
+    profileImageUrl,
     generation,
     role,
     track,
@@ -39,7 +41,8 @@ export default function UserInfo({
     const [isLoggingOut, setIsLoggingOut] = useState(false)
 
     const roleLabel = getRoleLabel(role)
-    const generationRoleText = generation !== undefined ? `${generation}기 ${roleLabel}` : roleLabel
+    const hasGeneration = typeof generation === "number" && Number.isFinite(generation)
+    const generationRoleText = hasGeneration ? `${generation}기 ${roleLabel}` : roleLabel
     const trackText = track ?? ""
     const isStaff = role === "STAFF"
     const rolePageLabel = isStaff ? "운영진 페이지" : "아기사자 페이지"
@@ -62,42 +65,102 @@ export default function UserInfo({
 
     return (
         <>
-            <div className="rounded-md bg-gray-6 px-3.5 pb-3.5 pt-7">
-                <div className="flex items-start justify-start px-3.5">
-                    <p className="ml-3.5 h-20 w-20 rounded-full bg-amber-300">img</p>
-                    <div className="ml-5 self-center">
-                        <p className="text-2xl font-bold text-white">
-                            {name}
-                            <span className="text-xl font-medium">님</span>
-                        </p>
-                        <p className="text-xs text-gray-4">{generationRoleText}</p>
+            <div className="md:hidden">
+                <button
+                    type="button"
+                    onClick={handleLogout}
+                    disabled={isLoggingOut}
+                    className="mb-2 text-xs text-gray-4 disabled:opacity-60"
+                >
+                    {isLoggingOut ? "로그아웃 중..." : "로그아웃"}
+                </button>
+
+                <div className="rounded-xl bg-[#4b5162] p-3">
+                    <div className="flex flex-col items-center text-center">
+                        {profileImageUrl ? (
+                            // eslint-disable-next-line @next/next/no-img-element
+                            <img
+                                src={profileImageUrl}
+                                alt={`${name} 프로필 이미지`}
+                                className="h-20 w-20 rounded-full object-cover"
+                            />
+                        ) : (
+                            <div className="h-20 w-20 rounded-full bg-gray-400" />
+                        )}
+                        <div className="mt-2">
+                            <p className="text-2xl font-bold text-white">
+                                {name}
+                                <span className="text-xl font-medium">님</span>
+                            </p>
+                            <p className="text-xs text-gray-4">{generationRoleText}</p>
+                        </div>
+                        {trackText ? (
+                            <span className="mt-2 rounded-4xl border border-gray-2 px-2.5 py-0.5 text-xs text-gray-1">
+                                {trackText}
+                            </span>
+                        ) : null}
                     </div>
-                    {trackText ? (
-                        <span className="ml-7 rounded-4xl border bg-transparent px-2 py-1 text-sm text-gray-1">
-                            {trackText}
-                        </span>
-                    ) : null}
-                </div>
-                <div className="mt-4 flex w-full justify-center gap-4">
-                    <button type="button" className="h-12 w-full rounded-md bg-gray-5">
-                        마이페이지
-                    </button>
-                    <Link
-                        href={rolePageHref}
-                        className="inline-flex h-12 w-full items-center justify-center rounded-md bg-gray-5"
-                    >
-                        {rolePageLabel}
-                    </Link>
+                    <div className="mt-4 flex w-full flex-col gap-3">
+                        <button type="button" className="h-10 w-full rounded-md bg-[#959aaa] text-sm text-white">
+                            마이 페이지
+                        </button>
+                        <Link
+                            href={rolePageHref}
+                            className="inline-flex h-10 w-full items-center justify-center rounded-md bg-[#959aaa] text-sm text-white"
+                        >
+                            {rolePageLabel}
+                        </Link>
+                    </div>
                 </div>
             </div>
-            <button
-                type="button"
-                onClick={handleLogout}
-                disabled={isLoggingOut}
-                className="mt-2 flex w-full justify-end text-sm text-gray-3 disabled:opacity-60"
-            >
-                {isLoggingOut ? "로그아웃 중..." : "로그아웃"}
-            </button>
+
+            <div className="hidden md:block">
+                <div className="rounded-md bg-gray-6 px-3.5 pb-3.5 pt-7">
+                    <div className="flex items-start justify-start px-3.5">
+                        {profileImageUrl ? (
+                            // eslint-disable-next-line @next/next/no-img-element
+                            <img
+                                src={profileImageUrl}
+                                alt={`${name} 프로필 이미지`}
+                                className="ml-3.5 h-20 w-20 rounded-full object-cover"
+                            />
+                        ) : (
+                            <div className="ml-3.5 h-20 w-20 rounded-full bg-amber-300" />
+                        )}
+                        <div className="ml-5 self-center">
+                            <p className="text-2xl font-bold text-white">
+                                {name}
+                                <span className="text-xl font-medium">님</span>
+                            </p>
+                            <p className="text-xs text-gray-4">{generationRoleText}</p>
+                        </div>
+                        {trackText ? (
+                            <span className="ml-7 rounded-4xl border bg-transparent px-2 py-1 text-sm text-gray-1">
+                                {trackText}
+                            </span>
+                        ) : null}
+                    </div>
+                    <div className="mt-4 flex w-full justify-center gap-4">
+                        <button type="button" className="h-12 w-full rounded-md bg-gray-5">
+                            마이페이지
+                        </button>
+                        <Link
+                            href={rolePageHref}
+                            className="inline-flex h-12 w-full items-center justify-center rounded-md bg-gray-5"
+                        >
+                            {rolePageLabel}
+                        </Link>
+                    </div>
+                </div>
+                <button
+                    type="button"
+                    onClick={handleLogout}
+                    disabled={isLoggingOut}
+                    className="mt-2 flex w-full justify-end text-sm text-gray-3 disabled:opacity-60"
+                >
+                    {isLoggingOut ? "로그아웃 중..." : "로그아웃"}
+                </button>
+            </div>
         </>
     )
 }

--- a/features/admin/AdminEntryPage.tsx
+++ b/features/admin/AdminEntryPage.tsx
@@ -2,7 +2,7 @@
 
 import Image from "next/image"
 import Link from "next/link"
-import type { CSSProperties, TouchEvent } from "react"
+import type { CSSProperties, MouseEvent, TouchEvent } from "react"
 import { useMemo, useRef, useState } from "react"
 
 type EntryItem = {
@@ -14,17 +14,17 @@ type EntryItem = {
 const ENTRY_ITEMS: EntryItem[] = [
     {
         title: "멋사 SYU 14TH\n지원자 관리",
-        description: "멋사 SYU 14TH 아기사자 지원내용을 확인하고\n합격/불합격 처리를 해요.",
+        description: "멋사 SYU 14TH 아기사자 지원 내역을 확인하고\n합격/불합격 처리를 해요.",
         href: "/admin/applicants",
     },
     {
         title: "멋사 SYU 14TH\n아기사자 관리",
-        description: "아기사자의 출결과 과제를 관리할 수 있어요.\n커뮤니티에 공지사항을 관리하고 질의응답을 하는 공간이에요.",
+        description: "아기사자의 출결과 과제를 관리할 수 있어요.\n커뮤니티와 공지사항도 함께 관리해요.",
         href: "/admin/baby-lions",
     },
     {
         title: "멋사 SYU 14TH\n운영진 주요업무",
-        description: "운영진의 주요업무를 수행합니다.\n아기사자와 홈페이지를 관리하는 공간이예요.",
+        description: "운영진의 주요 업무를 수행해요.\n아기사자용/스태프용 페이지를 관리해요.",
         href: "/admin/staff-tasks",
     },
 ]
@@ -36,6 +36,15 @@ export default function AdminEntryPage() {
 
     const goPrev = () => setActiveIndex((prev) => Math.max(0, prev - 1))
     const goNext = () => setActiveIndex((prev) => Math.min(lastIndex, prev + 1))
+
+    const handleCardClick = (event: MouseEvent<HTMLAnchorElement>, index: number) => {
+        if (index === activeIndex) {
+            return
+        }
+
+        event.preventDefault()
+        setActiveIndex(index)
+    }
 
     const handleTouchStart = (event: TouchEvent<HTMLElement>) => {
         touchStartXRef.current = event.touches[0]?.clientX ?? null
@@ -80,27 +89,23 @@ export default function AdminEntryPage() {
                                 className="flex transition-transform duration-700 ease-[cubic-bezier(0.22,1,0.36,1)]"
                                 style={mobileTrackStyle}
                             >
-                                {ENTRY_ITEMS.map((item) => (
-                                    <Link
-                                        key={item.title}
-                                        href={item.href}
-                                        className="w-full shrink-0 px-2 text-white"
-                                    >
+                                {ENTRY_ITEMS.map((item, index) => (
+                                    <div key={item.title} className="w-full shrink-0 px-2 text-white">
                                         <article className="h-[360px] w-full rounded-3xl border border-white/10 bg-[linear-gradient(145deg,#2a2f3b_0%,#20242f_100%)] px-7 py-8 shadow-[0_18px_40px_rgba(0,0,0,0.35)]">
-                                            <p className="text-xs font-semibold tracking-[0.14em] text-[#8a95b2]">
-                                                ADMIN ENTRY
-                                            </p>
-                                            <h2 className="mt-5 whitespace-normal break-words text-[33px] font-extrabold leading-[1.12] tracking-[-0.02em]">
-                                                {item.title}
-                                            </h2>
-                                            <p className="mt-5 whitespace-pre-line break-words text-[15px] leading-[1.5] text-[#9aa2b4]">
-                                                {item.description}
-                                            </p>
+                                            <p className="text-xs font-semibold tracking-[0.14em] text-[#8a95b2]">ADMIN ENTRY</p>
+                                            <Link href={item.href} onClick={(event) => handleCardClick(event, index)} className="mt-5 block">
+                                                <h2 className="whitespace-normal break-words text-[33px] font-extrabold leading-[1.12] tracking-[-0.02em]">
+                                                    {item.title}
+                                                </h2>
+                                                <p className="mt-5 whitespace-pre-line break-words text-[15px] leading-[1.5] text-[#9aa2b4]">
+                                                    {item.description}
+                                                </p>
+                                            </Link>
                                             <div className="mt-8 inline-flex h-10 items-center justify-center rounded-full bg-[#4a5162] px-4 text-sm font-semibold text-white">
                                                 바로가기
                                             </div>
                                         </article>
-                                    </Link>
+                                    </div>
                                 ))}
                             </div>
                         </div>
@@ -120,32 +125,37 @@ export default function AdminEntryPage() {
                             }
 
                             return (
-                                <Link
+                                <div
                                     key={item.title}
-                                    href={item.href}
                                     style={desktopCardStyle}
-                                    className={`absolute left-1/2 top-0 block text-white transition-[transform,opacity] duration-700 ease-[cubic-bezier(0.22,1,0.36,1)] ${isActive
-                                            ? "z-30 min-h-[520px] w-[44vw] min-w-[520px] max-w-[760px] opacity-100 overflow-visible"
-                                            : isNear
-                                                ? "z-20 min-h-[520px] w-[44vw] min-w-[520px] max-w-[760px] opacity-45 overflow-visible"
-                                                : "pointer-events-none z-10 min-h-[520px] w-[44vw] min-w-[520px] max-w-[760px] opacity-0 overflow-visible"
+                                    className={`pointer-events-none absolute left-1/2 top-0 block text-white transition-[transform,opacity] duration-700 ease-[cubic-bezier(0.22,1,0.36,1)] ${isActive
+                                        ? "z-30 min-h-[520px] w-[44vw] min-w-[520px] max-w-[760px] opacity-100 overflow-visible"
+                                        : isNear
+                                            ? "z-20 min-h-[520px] w-[44vw] min-w-[520px] max-w-[760px] opacity-45 overflow-visible"
+                                            : "z-10 min-h-[520px] w-[44vw] min-w-[520px] max-w-[760px] opacity-0 overflow-visible"
                                         }`}
                                 >
                                     <div className="-rotate-[7deg] origin-center px-8 py-6">
-                                        <h2
-                                            className={`ml-auto w-fit whitespace-pre text-right font-extrabold leading-[1.08] tracking-[-0.02em] ${isActive ? "text-[46px]" : "text-[30px]"
-                                                }`}
+                                        <Link
+                                            href={item.href}
+                                            onClick={(event) => handleCardClick(event, index)}
+                                            className="pointer-events-auto ml-auto block w-fit text-right"
                                         >
-                                            {item.title}
-                                        </h2>
-                                        <p
-                                            className={`mt-3 whitespace-pre text-right text-[#9aa2b4] ${isActive ? "text-sm" : "text-xs"
-                                                }`}
-                                        >
-                                            {item.description}
-                                        </p>
+                                            <h2
+                                                className={`whitespace-pre font-extrabold leading-[1.08] tracking-[-0.02em] ${isActive ? "text-[46px]" : "text-[30px]"
+                                                    }`}
+                                            >
+                                                {item.title}
+                                            </h2>
+                                            <p
+                                                className={`mt-3 whitespace-pre text-[#9aa2b4] ${isActive ? "text-sm" : "text-xs"
+                                                    }`}
+                                            >
+                                                {item.description}
+                                            </p>
+                                        </Link>
                                     </div>
-                                </Link>
+                                </div>
                             )
                         })}
                     </div>

--- a/features/public/api.ts
+++ b/features/public/api.ts
@@ -13,6 +13,7 @@ import type {
     ResetPasswordVerifyRequest,
     RefreshTokenResponse,
     SendEmailCodeRequest,
+    UploadProfileImageResponse,
     VerifyEmailCodeRequest,
 } from "@/features/public/type"
 import { isAxiosError } from "axios"
@@ -103,41 +104,8 @@ export async function register(payload: RegisterPayload): Promise<RegisterRespon
         enrollment: payload.enrollment,
         birthDate: payload.birthDate,
         phone: payload.phone,
+        profileImageId: payload.profileImageId,
     }
-
-    if (payload.profileImage) {
-        const multipartBody = {
-            ...requestBody,
-            profileImage: payload.profileImage,
-        }
-
-        console.log("[register] request mode: multipart/form-data (auto)")
-        console.log("[register] request payload:", {
-            ...requestBody,
-            password: `***masked*** (${requestBody.password.length} chars)`,
-            profileImage: {
-                name: payload.profileImage.name,
-                type: payload.profileImage.type,
-                size: payload.profileImage.size,
-            },
-        })
-
-        try {
-            const response = await apiClient.postForm<RegisterResponse>("/auth/register", multipartBody)
-            return response.data
-        } catch (error) {
-            if (isAxiosError(error)) {
-                console.error("[register] failed response:", {
-                    status: error.response?.status,
-                    data: error.response?.data,
-                })
-            } else {
-                console.error("[register] unexpected error:", error)
-            }
-            throw error
-        }
-    }
-
     console.log("[register] request mode: application/json")
     console.log("[register] request payload:", {
         ...requestBody,
@@ -155,6 +123,33 @@ export async function register(payload: RegisterPayload): Promise<RegisterRespon
             })
         } else {
             console.error("[register] unexpected error:", error)
+        }
+        throw error
+    }
+}
+
+export async function uploadProfileImage(profileImage: File): Promise<UploadProfileImageResponse> {
+    try {
+        const response = await apiClient.postForm<UploadProfileImageResponse>(
+            "/auth/profile-image",
+            {
+                profileImage,
+            },
+            {
+                timeout: 60000,
+            },
+        )
+        return response.data
+    } catch (error) {
+        if (isAxiosError(error)) {
+            console.error("[uploadProfileImage] failed response:", {
+                status: error.response?.status,
+                data: error.response?.data,
+                code: error.code,
+                message: error.message,
+            })
+        } else {
+            console.error("[uploadProfileImage] unexpected error:", error)
         }
         throw error
     }

--- a/features/public/auth/LoginPage.tsx
+++ b/features/public/auth/LoginPage.tsx
@@ -2,14 +2,17 @@
 
 import Image from "next/image"
 import Link from "next/link"
-import { FormEvent, useState } from "react"
+import { FormEvent, useEffect, useState } from "react"
 import { useRouter } from "next/navigation"
 import { login } from "@/features/public/api"
+
+const REMEMBER_LOGIN_ID_KEY = "rememberLoginId"
 
 export default function LoginPageFeature() {
     const router = useRouter()
     const [loginId, setLoginId] = useState("")
     const [password, setPassword] = useState("")
+    const [rememberLoginInfo, setRememberLoginInfo] = useState(false)
     const [errorMessage, setErrorMessage] = useState("")
     const [isSubmitting, setIsSubmitting] = useState(false)
     const authInputClass =
@@ -25,11 +28,30 @@ export default function LoginPageFeature() {
             router.push("/")
             router.refresh()
         } catch {
-            setErrorMessage("아이디 또는 비밀번호를 확인해주세요.")
+            setErrorMessage("아이디 또는 비밀번호를 확인해 주세요.")
         } finally {
             setIsSubmitting(false)
         }
     }
+
+    useEffect(() => {
+        const savedLoginId = window.localStorage.getItem(REMEMBER_LOGIN_ID_KEY)
+        if (!savedLoginId) {
+            return
+        }
+
+        setLoginId(savedLoginId)
+        setRememberLoginInfo(true)
+    }, [])
+
+    useEffect(() => {
+        if (rememberLoginInfo) {
+            window.localStorage.setItem(REMEMBER_LOGIN_ID_KEY, loginId)
+            return
+        }
+
+        window.localStorage.removeItem(REMEMBER_LOGIN_ID_KEY)
+    }, [loginId, rememberLoginInfo])
 
     return (
         <div className="relative mx-auto mt-27 w-full max-w-4xl pt-28">
@@ -42,9 +64,9 @@ export default function LoginPageFeature() {
                 priority
             />
 
-            <section className="relative z-10 h-[calc(100vh-220px)] w-full rounded-t-[56px] bg-[linear-gradient(180deg,#484D5A_-23.29%,#303136_46.27%)] px-4 pb-9 pt-16 md:rounded-t-[225px]">
+            <section className="relative z-10 min-h-[calc(100dvh-220px)] w-full rounded-t-[56px] bg-[linear-gradient(180deg,#484D5A_-23.29%,#303136_46.27%)] px-4 pb-9 pt-16 md:rounded-t-[225px]">
                 <form onSubmit={handleSubmit} className="flex flex-col items-center justify-center space-y-4">
-                    <div className="flex h-[61px] w-[61px] items-center justify-center justify-self-center rounded-full bg-foreground p-1 md:h-52 md:w-52 md:p-6">
+                    <div className="flex h-[73px] w-[73px] items-center justify-center justify-self-center rounded-full bg-foreground p-[6px] md:h-[243px] md:w-[243px] md:p-[23px]">
                         <Image
                             src="/images/syuLikelion.webp"
                             alt="LIKELION 14TH"
@@ -55,8 +77,19 @@ export default function LoginPageFeature() {
                         />
                     </div>
 
-                    <label className="block">
-                        <span className="mb-2 block text-lg font-bold text-foreground md:text-xl">ID</span>
+                    <label className="block w-80.75 md:w-122">
+                        <div className="mb-2 flex items-center justify-between">
+                            <span className="text-lg font-bold text-foreground md:text-xl">ID</span>
+                            <span className="inline-flex items-center gap-2 text-base font-normal text-gray-2">
+                                <input
+                                    type="checkbox"
+                                    checked={rememberLoginInfo}
+                                    onChange={(event) => setRememberLoginInfo(event.target.checked)}
+                                    className="h-6 w-6 accent-main-1"
+                                />
+                                로그인 정보 기억하기
+                            </span>
+                        </div>
                         <input
                             type="text"
                             value={loginId}

--- a/features/public/auth/SignupPage.tsx
+++ b/features/public/auth/SignupPage.tsx
@@ -9,6 +9,7 @@ import {
     checkStudentNoAvailability,
     register,
     sendEmailCode,
+    uploadProfileImage,
     verifyEmailCode,
 } from "@/features/public/api"
 
@@ -223,6 +224,16 @@ export default function SignupPageFeature() {
 
         setIsSubmitting(true)
         try {
+            let profileImageId: number | undefined
+            if (profileImage) {
+                const uploadResult = await uploadProfileImage(profileImage)
+                if (!uploadResult.ok) {
+                    setErrorMessage("프로필 이미지 업로드에 실패했습니다.")
+                    return
+                }
+                profileImageId = uploadResult.profileImageId
+            }
+
             const result = await register({
                 loginId: form.loginId,
                 email: form.email,
@@ -234,7 +245,7 @@ export default function SignupPageFeature() {
                 enrollment: form.enrollment,
                 birthDate,
                 phone: form.phone,
-                profileImage,
+                profileImageId,
             })
             setMessage(`회원가입이 완료되었습니다. (${result.userUuid}) 로그인 페이지로 이동해주세요.`)
         } catch {

--- a/features/public/type.ts
+++ b/features/public/type.ts
@@ -16,6 +16,14 @@ export type HomepageProfile = {
     enrollment: "ENROLLED" | string
     birthDate: string
     phone: string
+    profileImage?: {
+        url: string
+        originalFilename: string
+        contentType: string
+        fileSize: number
+        uploadedAt: string
+    } | null
+    profileImageUrl?: string | null
     status: "ACTIVE" | string
     createdAt: string
     updatedAt: string
@@ -104,12 +112,16 @@ export type RegisterRequest = {
     enrollment: string
     birthDate: string
     phone: string
+    profileImageId?: number
 }
 
-export type RegisterPayload = RegisterRequest & {
-    profileImage?: File | null
-}
+export type RegisterPayload = RegisterRequest
 
 export type RegisterResponse = {
     userUuid: string
+}
+
+export type UploadProfileImageResponse = {
+    ok: boolean
+    profileImageId: number
 }


### PR DESCRIPTION
## 📎 관련 이슈
Closes #20

## 📝 작업 내용
- 회원가입 API 플로우를 `프로필 이미지 선업로드 -> profileImageId 포함 회원가입` 구조로 변경하고 관련 타입/호출 로직을 반영
- 로그인 페이지에 `로그인 유지하기` 체크 기능을 추가하고, 로컬 스토리지 연동 및 한글 깨짐 문구를 복구
- 모바일 사이드바 UI를 재구성(오버레이 블러 포함)하고, PC UI는 기존을 유지하도록 분리했으며, 어드민 Entry 카드 클릭 인터랙션을 개선

## 체크리스트
- [ ] 포메팅이 적용되었습니다.

## 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)

## 💬 비고