### PR TITLE
feat: 관리자 지원자/합격자 목록-상세 분할 뷰 및 조회 UX 개선

### DIFF
--- a/app/admin/applicants/[applicationId]/page.tsx
+++ b/app/admin/applicants/[applicationId]/page.tsx
@@ -1,0 +1,14 @@
+﻿import { redirect } from "next/navigation";
+
+type AdminApplicantDetailRouteProps = {
+  params: Promise<{
+    applicationId: string;
+  }>;
+};
+
+export default async function AdminApplicantDetailRoute({
+  params,
+}: AdminApplicantDetailRouteProps) {
+  const resolvedParams = await params;
+  redirect(`/admin/applications/${resolvedParams.applicationId}`);
+}

--- a/app/admin/applicants/page.tsx
+++ b/app/admin/applicants/page.tsx
@@ -1,0 +1,5 @@
+import { redirect } from "next/navigation";
+
+export default function AdminApplicantsPage() {
+  redirect("/admin/applications");
+}

--- a/app/admin/applications/[applicationId]/page.tsx
+++ b/app/admin/applications/[applicationId]/page.tsx
@@ -1,0 +1,18 @@
+﻿import ApplicationDetailPage from "@/features/admin/applications/ApplicationDetailPage";
+
+type AdminApplicationDetailRouteProps = {
+  params: Promise<{
+    applicationId: string;
+  }>;
+};
+
+export default async function AdminApplicationDetailRoute({
+  params,
+}: AdminApplicationDetailRouteProps) {
+  const resolvedParams = await params;
+  const parsed = Number(resolvedParams.applicationId);
+  if (!Number.isInteger(parsed) || parsed <= 0) {
+    return <div className="px-4 py-16 text-white">잘못된 지원서 ID입니다.</div>;
+  }
+  return <ApplicationDetailPage applicationId={parsed} />;
+}

--- a/app/admin/applications/page.tsx
+++ b/app/admin/applications/page.tsx
@@ -1,0 +1,6 @@
+import ApplicationsListPage from "@/features/admin/applications/ApplicationsListPage";
+
+export default function AdminApplicationsPage() {
+  return <ApplicationsListPage />;
+}
+

--- a/app/admin/interviews/candidates/[applicationId]/page.tsx
+++ b/app/admin/interviews/candidates/[applicationId]/page.tsx
@@ -1,0 +1,18 @@
+﻿import InterviewCandidateDetailPage from "@/features/admin/interviews/InterviewCandidateDetailPage";
+
+type AdminInterviewCandidateDetailRouteProps = {
+  params: Promise<{
+    applicationId: string;
+  }>;
+};
+
+export default async function AdminInterviewCandidateDetailRoute({
+  params,
+}: AdminInterviewCandidateDetailRouteProps) {
+  const resolvedParams = await params;
+  const parsed = Number(resolvedParams.applicationId);
+  if (!Number.isInteger(parsed) || parsed <= 0) {
+    return <div className="px-4 py-16 text-white">잘못된 지원서 ID입니다.</div>;
+  }
+  return <InterviewCandidateDetailPage applicationId={parsed} />;
+}

--- a/app/admin/interviews/candidates/page.tsx
+++ b/app/admin/interviews/candidates/page.tsx
@@ -1,0 +1,6 @@
+import InterviewCandidatesListPage from "@/features/admin/interviews/InterviewCandidatesListPage";
+
+export default function AdminInterviewCandidatesPage() {
+  return <InterviewCandidatesListPage />;
+}
+

--- a/app/admin/layout.tsx
+++ b/app/admin/layout.tsx
@@ -3,8 +3,8 @@ import "@/styles/globals.css";
 import Header from "@/components/layout/Header";
 
 export const metadata: Metadata = {
-  title: "삼육멋사14기 운영페이지",
-  description: "멋쟁이사자처럼 14기 사이트",
+  title: "멋쟁이사자처럼14기 운영페이지",
+  description: "멋쟁이사자처럼 14기 관리자 페이지",
   icons: {
     icon: "/favicon.svg",
   },

--- a/features/admin/AdminEntryPage.tsx
+++ b/features/admin/AdminEntryPage.tsx
@@ -1,4 +1,4 @@
-"use client"
+﻿"use client"
 
 import Image from "next/image"
 import Link from "next/link"
@@ -14,17 +14,17 @@ type EntryItem = {
 const ENTRY_ITEMS: EntryItem[] = [
     {
         title: "멋사 SYU 14TH\n지원자 관리",
-        description: "멋사 SYU 14TH 아기사자 지원 내역을 확인하고\n합격/불합격 처리를 해요.",
-        href: "/admin/applicants",
+        description: "멋사 SYU 14TH 서류 지원자 목록을 확인하고\n합격/불합격 처리를 해요.",
+        href: "/admin/applications",
     },
     {
-        title: "멋사 SYU 14TH\n아기사자 관리",
-        description: "아기사자의 출결과 과제를 관리할 수 있어요.\n커뮤니티와 공지사항도 함께 관리해요.",
-        href: "/admin/baby-lions",
+        title: "멋사 SYU 14TH\n면접자 관리",
+        description: "면접 대상자 출결과 과제를 관리하고\n커뮤니티와 공지사항 운영을 진행해요.",
+        href: "/admin/interviews/candidates",
     },
     {
         title: "멋사 SYU 14TH\n운영진 주요업무",
-        description: "운영진의 주요 업무를 수행해요.\n아기사자용/스태프용 페이지를 관리해요.",
+        description: "운영진의 주요 업무를 수행해요.\n지원자와 스태프 운영 페이지를 관리해요.",
         href: "/admin/staff-tasks",
     },
 ]

--- a/features/admin/applications/ApplicationDetailPage.tsx
+++ b/features/admin/applications/ApplicationDetailPage.tsx
@@ -1,0 +1,476 @@
+"use client";
+
+import Link from "next/link";
+import { useSearchParams } from "next/navigation";
+import { useEffect, useMemo, useState } from "react";
+import {
+  getAdminApplicationDetail,
+  getAdminDocumentScoresDetail,
+  getMyAdminDocumentScores,
+  postAdminDocumentPendingDecision,
+  upsertMyAdminDocumentScores,
+} from "../api";
+import type {
+  AdminApplicationDetailResponse,
+  AdminDocumentScoresDetailResponse,
+} from "../type";
+import { getMyInfo } from "@/features/public/api";
+
+type ApplicationDetailPageProps = {
+  applicationId: number;
+  embedded?: boolean;
+  onClose?: () => void;
+};
+
+type DetailTab = "document" | "score" | "review";
+
+function formatPart(value: string) {
+  if (value === "FRONTEND") return "FRONTEND";
+  if (value === "BACKEND") return "BACKEND";
+  if (value === "AI_ML") return "AI/ML";
+  if (value === "PM_DESIGN") return "PM/DESIGN";
+  return value;
+}
+
+function formatEnrollment(value: string) {
+  const upper = value.toUpperCase();
+  if (upper === "ENROLLED") return "재학";
+  if (upper === "LEAVE") return "휴학";
+  if (upper === "GRADUATED") return "졸업";
+  return value;
+}
+
+function formatDateTime(value: string) {
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return "-";
+  return new Intl.DateTimeFormat("ko-KR", {
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+    hour12: false,
+    timeZone: "Asia/Seoul",
+  }).format(date);
+}
+
+function getTabLabel(tab: DetailTab) {
+  if (tab === "document") return "서류 보기";
+  if (tab === "score") return "점수 매기기";
+  return "점수 현황";
+}
+
+export default function ApplicationDetailPage({
+  applicationId,
+  embedded = false,
+  onClose,
+}: ApplicationDetailPageProps) {
+  const searchParams = useSearchParams();
+  const listQuery = searchParams.toString();
+  const listHref = `/admin/applications${listQuery ? `?${listQuery}` : ""}`;
+
+  const [activeTab, setActiveTab] = useState<DetailTab>("document");
+  const [isLoading, setIsLoading] = useState(true);
+  const [isSaving, setIsSaving] = useState(false);
+  const [detailError, setDetailError] = useState("");
+  const [scoreError, setScoreError] = useState("");
+  const [saveMessage, setSaveMessage] = useState("");
+  const [detail, setDetail] = useState<AdminApplicationDetailResponse | null>(
+    null,
+  );
+  const [scores, setScores] = useState<Record<number, number>>({});
+  const [comment, setComment] = useState("");
+  const [isAdmin, setIsAdmin] = useState(false);
+  const [isPendingDecisionLoading, setIsPendingDecisionLoading] = useState(false);
+  const [pendingDecisionMessage, setPendingDecisionMessage] = useState("");
+  const [documentScoreDetail, setDocumentScoreDetail] =
+    useState<AdminDocumentScoresDetailResponse | null>(null);
+
+  useEffect(() => {
+    let mounted = true;
+
+    const load = async () => {
+      setIsLoading(true);
+      setDetailError("");
+      setScoreError("");
+      setSaveMessage("");
+      setPendingDecisionMessage("");
+
+      try {
+        const detailResponse = await getAdminApplicationDetail(applicationId);
+        if (!mounted) return;
+        setDetail(detailResponse);
+
+        const [meResult, myScoreResult, scoreDetailResult] =
+          await Promise.allSettled([
+            getMyInfo(),
+            getMyAdminDocumentScores(applicationId),
+            getAdminDocumentScoresDetail(applicationId),
+          ]);
+
+        if (!mounted) return;
+
+        if (meResult.status === "fulfilled") {
+          const hasAdminRole =
+            meResult.value.sso.ssoRole === "ADMIN" ||
+            meResult.value.roles.some(
+              (role) =>
+                role.level === "ADMIN" ||
+                role.position === "PRESIDENT" ||
+                role.position === "VICE_PRESIDENT",
+            );
+          setIsAdmin(hasAdminRole);
+        } else {
+          setIsAdmin(false);
+        }
+
+        if (myScoreResult.status === "fulfilled") {
+          setScores(
+            Object.fromEntries(
+              myScoreResult.value.scores.map((item) => [item.questionId, item.score]),
+            ) as Record<number, number>,
+          );
+          setComment(myScoreResult.value.comment ?? "");
+        } else {
+          setScores({});
+          setComment("");
+          setScoreError(
+            "내 점수 정보를 불러오지 못했습니다. 점수 매기기 탭 저장 시 다시 시도됩니다.",
+          );
+        }
+
+        if (scoreDetailResult.status === "fulfilled") {
+          setDocumentScoreDetail(scoreDetailResult.value);
+        } else {
+          setDocumentScoreDetail(null);
+          setScoreError(
+            "운영진 점수 현황을 불러오지 못했습니다. 잠시 후 다시 시도해 주세요.",
+          );
+        }
+      } catch {
+        if (!mounted) return;
+        setDetailError("지원서 상세를 불러오지 못했습니다.");
+      } finally {
+        if (!mounted) return;
+        setIsLoading(false);
+      }
+    };
+
+    void load();
+
+    return () => {
+      mounted = false;
+    };
+  }, [applicationId]);
+
+  const scoredQuestions = useMemo(() => {
+    if (!detail) return [];
+    return detail.answers.map((answer) => ({
+      questionId: answer.questionId,
+      content: answer.content,
+      answer: answer.answer,
+      score: scores[answer.questionId] ?? 0,
+    }));
+  }, [detail, scores]);
+
+  const handleSave = async () => {
+    if (!detail || isSaving) return;
+    setIsSaving(true);
+    setSaveMessage("");
+    setScoreError("");
+
+    try {
+      await upsertMyAdminDocumentScores(applicationId, {
+        scores: scoredQuestions.map((item) => ({
+          questionId: item.questionId,
+          score: item.score,
+        })),
+        comment,
+      });
+      setSaveMessage("점수를 저장했습니다.");
+    } catch {
+      setScoreError("점수 저장에 실패했습니다.");
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  const handlePendingDecision = async (decision: "PASS" | "FAIL") => {
+    if (!detail || !isAdmin || isPendingDecisionLoading) return;
+    setIsPendingDecisionLoading(true);
+    setPendingDecisionMessage("");
+    setScoreError("");
+
+    try {
+      await postAdminDocumentPendingDecision({
+        recruitmentId: detail.recruitmentId,
+        passIds: decision === "PASS" ? [detail.applicationId] : [],
+        failIds: decision === "FAIL" ? [detail.applicationId] : [],
+      });
+      setPendingDecisionMessage(
+        decision === "PASS"
+          ? "서류 합격 예정으로 처리했습니다."
+          : "서류 불합격 예정으로 처리했습니다.",
+      );
+    } catch {
+      setScoreError("합격/불합격 예정 처리에 실패했습니다.");
+    } finally {
+      setIsPendingDecisionLoading(false);
+    }
+  };
+
+  const detailBody = (
+    <div className={`${embedded ? "" : "mt-6"} rounded-2xl bg-[#323640] p-6 lg:p-8`}>
+      <h2 className="text-[36px] font-bold lg:text-[44px]">{formatPart(detail?.applyPart ?? "-")}</h2>
+
+      {detail && (
+        <>
+          <dl className="mt-6 grid grid-cols-[110px_1fr] gap-y-2 text-sm text-gray-3 lg:max-w-[520px]">
+            <dt className="font-semibold text-gray-2">학과</dt>
+            <dd>{detail.applicant.department}</dd>
+            <dt className="font-semibold text-gray-2">학번</dt>
+            <dd>{detail.applicant.studentNoPrefix}학번</dd>
+            <dt className="font-semibold text-gray-2">학적상태</dt>
+            <dd>
+              {detail.applicant.grade}학년 {formatEnrollment(detail.applicant.enrollment)}
+            </dd>
+            <dt className="font-semibold text-gray-2">지원일시</dt>
+            <dd>{formatDateTime(detail.submittedAt)}</dd>
+          </dl>
+
+          {documentScoreDetail && (
+            <p className="mt-4 text-sm text-gray-4">
+              평가 {documentScoreDetail.reviewCount}명, 평균 점수{" "}
+              {documentScoreDetail.average.toFixed(2)}
+            </p>
+          )}
+        </>
+      )}
+
+      <div className="mt-6 flex flex-wrap gap-2 border-b border-[#606673] pb-4">
+        {(["document", "score", "review"] as const).map((tab) => (
+          <button
+            key={tab}
+            type="button"
+            onClick={() => setActiveTab(tab)}
+            className={`rounded-lg px-4 py-2 text-sm font-semibold transition-colors ${
+              activeTab === tab
+                ? "bg-main-1 text-white"
+                : "bg-[#454c5a] text-gray-2 hover:bg-[#565f70]"
+            }`}
+          >
+            {getTabLabel(tab)}
+          </button>
+        ))}
+      </div>
+
+      {isLoading && <p className="mt-6 text-sm text-gray-3">로딩 중...</p>}
+      {!isLoading && detailError && (
+        <p className="mt-6 text-sm text-[#ff9ea8]">{detailError}</p>
+      )}
+
+      {!isLoading && detail && activeTab === "document" && (
+        <div className="mt-8 space-y-8">
+          {detail.answers.map((answer, index) => (
+            <article key={answer.questionId} className="space-y-3">
+              <h3 className="text-lg font-semibold">
+                문항 {index + 1}. {answer.content}
+              </h3>
+              <p className="whitespace-pre-wrap rounded-lg bg-[#404654] p-4 text-sm text-gray-2">
+                {answer.answer}
+              </p>
+            </article>
+          ))}
+        </div>
+      )}
+
+      {!isLoading && detail && activeTab === "score" && (
+        <div className="mt-8">
+          <div className="space-y-8">
+            {scoredQuestions.map((item, index) => (
+              <article key={item.questionId} className="space-y-3">
+                <h3 className="text-lg font-semibold">
+                  문항 {index + 1}. {item.content}
+                </h3>
+                <p className="whitespace-pre-wrap rounded-lg bg-[#404654] p-4 text-sm text-gray-2">
+                  {item.answer}
+                </p>
+                <div className="flex items-center gap-3">
+                  <label className="text-sm text-gray-3">문항 점수</label>
+                  <input
+                    type="number"
+                    min={0}
+                    max={10}
+                    step={1}
+                    value={item.score}
+                    onChange={(event) => {
+                      const numeric = Number(event.target.value);
+                      const next = Number.isFinite(numeric)
+                        ? Math.max(0, Math.min(10, numeric))
+                        : 0;
+                      setScores((prev) => ({
+                        ...prev,
+                        [item.questionId]: next,
+                      }));
+                    }}
+                    className="h-9 w-24 rounded-md border border-[#666d7d] bg-[#505767] px-3 text-sm outline-none focus:border-main-1"
+                  />
+                </div>
+              </article>
+            ))}
+          </div>
+
+          <div className="my-8 h-px bg-[#606673]" />
+
+          <div className="space-y-3">
+            <h3 className="text-[22px] font-semibold">총평 코멘트</h3>
+            <textarea
+              value={comment}
+              onChange={(event) => setComment(event.target.value)}
+              rows={5}
+              placeholder="코멘트를 입력해 주세요."
+              className="w-full resize-none rounded-xl border border-[#62697A] bg-[#4C5262] p-4 text-sm text-white placeholder:text-gray-4 outline-none focus:border-main-1"
+            />
+          </div>
+
+          <div className="mt-8 flex justify-center">
+            <button
+              type="button"
+              onClick={handleSave}
+              disabled={isSaving}
+              className="rounded-lg bg-main-1 px-10 py-3 text-sm font-semibold disabled:opacity-60"
+            >
+              {isSaving ? "저장 중..." : "점수 저장"}
+            </button>
+          </div>
+        </div>
+      )}
+
+      {!isLoading && detail && activeTab === "review" && (
+        <div className="mt-8 space-y-5">
+          {documentScoreDetail ? (
+            <>
+              <div className="rounded-lg bg-[#404654] px-4 py-3 text-sm text-gray-2">
+                리뷰어 수: {documentScoreDetail.reviewCount}명, 평균:{" "}
+                {documentScoreDetail.average.toFixed(2)}
+              </div>
+
+              {documentScoreDetail.canViewOthersScores &&
+                documentScoreDetail.reviews.map((review, idx) => (
+                  <article
+                    key={`${review.reviewer.name}-${idx}`}
+                    className="rounded-xl border border-[#4a5162] bg-[#3a404d] p-4"
+                  >
+                    <p className="text-sm font-semibold">
+                      {review.reviewer.name} ({review.reviewer.part})
+                    </p>
+                    <p className="mt-1 text-xs text-gray-4">총점: {review.total}</p>
+                    <div className="mt-3 flex flex-wrap gap-2">
+                      {review.scores.map((score) => (
+                        <span
+                          key={score.questionId}
+                          className="rounded-md bg-[#4f5668] px-2 py-1 text-xs"
+                        >
+                          Q{score.questionId}: {score.score}
+                        </span>
+                      ))}
+                    </div>
+                    <p className="mt-3 whitespace-pre-wrap rounded-md bg-[#454c5a] p-3 text-sm text-gray-2">
+                      {review.comment || "-"}
+                    </p>
+                  </article>
+                ))}
+
+              {isAdmin && (
+                <div className="mt-4 flex flex-wrap items-center gap-3">
+                  <button
+                    type="button"
+                    onClick={() => handlePendingDecision("PASS")}
+                    disabled={isPendingDecisionLoading}
+                    className="rounded-lg bg-[#1f9d55] px-6 py-2.5 text-sm font-semibold disabled:opacity-60"
+                  >
+                    서류 합격 예정
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => handlePendingDecision("FAIL")}
+                    disabled={isPendingDecisionLoading}
+                    className="rounded-lg bg-[#cc3a3a] px-6 py-2.5 text-sm font-semibold disabled:opacity-60"
+                  >
+                    서류 불합격 예정
+                  </button>
+                </div>
+              )}
+            </>
+          ) : (
+            <p className="text-sm text-gray-3">점수 상세 정보를 불러오지 못했습니다.</p>
+          )}
+        </div>
+      )}
+
+      {scoreError && <p className="mt-4 text-sm text-[#ff9ea8]">{scoreError}</p>}
+      {saveMessage && <p className="mt-2 text-sm text-[#8fd3ff]">{saveMessage}</p>}
+      {pendingDecisionMessage && (
+        <p className="mt-2 text-sm text-[#8fd3ff]">{pendingDecisionMessage}</p>
+      )}
+    </div>
+  );
+
+  if (embedded) {
+    return (
+      <div className="rounded-2xl border border-[#3a3d45] bg-[#2d3037] p-4">
+        <div className="mb-3 flex items-center justify-between">
+          <h3 className="text-sm font-semibold text-gray-2">지원서 상세</h3>
+          {onClose && (
+            <button
+              type="button"
+              onClick={onClose}
+              className="rounded-md bg-[#454c5a] px-3 py-1.5 text-xs"
+            >
+              닫기
+            </button>
+          )}
+        </div>
+        {detailBody}
+      </div>
+    );
+  }
+
+  return (
+    <section className="bg-background px-4 py-10 text-white lg:px-8 lg:py-14">
+      <div className="mx-auto max-w-[1200px]">
+        <div className="grid gap-4 lg:grid-cols-[220px_1fr]">
+          <aside className="rounded-2xl border border-[#3a3d45] bg-[#26282d] p-4">
+            <p className="text-xs font-semibold text-gray-4">목록</p>
+            <div className="mt-4 space-y-2">
+              <Link
+                href="/admin/applications"
+                className="block rounded-lg border-l-2 border-main-1 bg-[#2f323a] px-3 py-2 text-left text-[17px] text-white"
+              >
+                서류 지원서 목록
+              </Link>
+              <Link
+                href="/admin/interviews/candidates"
+                className="block rounded-lg px-3 py-2 text-left text-[17px] text-gray-4"
+              >
+                서류 합격자 목록
+              </Link>
+            </div>
+          </aside>
+
+          <div className="rounded-2xl border border-[#3a3d45] bg-[#2d3037] p-4 lg:p-6">
+            <div className="flex justify-end">
+              <Link
+                href={listHref}
+                className="rounded-lg bg-main-1 px-6 py-3 text-sm font-semibold"
+              >
+                목록 보기
+              </Link>
+            </div>
+            {detailBody}
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/features/admin/applications/ApplicationsListPage.tsx
+++ b/features/admin/applications/ApplicationsListPage.tsx
@@ -1,0 +1,399 @@
+﻿"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
+import Link from "next/link";
+import { getAdminApplications, getRecruitments } from "../api";
+import type {
+  AdminApplicationListResponse,
+  AdminApplicationStatus,
+  AdminApplyPart,
+  AdminRecruitmentListItem,
+} from "../type";
+import ApplicantFilters from "../components/ApplicantFilters";
+import ApplicantPagination from "../components/ApplicantPagination";
+import ApplicantTable from "../components/ApplicantTable";
+import ApplicationDetailPage from "./ApplicationDetailPage";
+
+const PAGE_SIZE = 12;
+const PAGE_BUTTON_LIMIT = 10;
+
+const EMPTY_PAGE: AdminApplicationListResponse = {
+  items: [],
+  page: {
+    page: 0,
+    size: PAGE_SIZE,
+    totalElements: 0,
+    totalPages: 0,
+  },
+};
+
+export default function ApplicationsListPage() {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const [recruitments, setRecruitments] = useState<AdminRecruitmentListItem[]>([]);
+  const [isRecruitmentsLoading, setIsRecruitmentsLoading] = useState(false);
+  const [selectedRecruitmentId, setSelectedRecruitmentId] = useState("");
+  const [recruitmentId, setRecruitmentId] = useState<number | null>(null);
+  const [part, setPart] = useState<"ALL" | AdminApplyPart>("ALL");
+  const [status, setStatus] = useState<"ALL" | AdminApplicationStatus>("ALL");
+  const [page, setPage] = useState(0);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState("");
+  const [result, setResult] = useState<AdminApplicationListResponse>(EMPTY_PAGE);
+
+  const selectedApplicationId = useMemo(() => {
+    const parsed = Number(searchParams.get("applicationId"));
+    if (!Number.isInteger(parsed) || parsed <= 0) return null;
+    return parsed;
+  }, [searchParams]);
+
+  const resolvedStatus = useMemo(
+    () => (status === "ALL" ? undefined : status),
+    [status],
+  );
+  const resolvedPart = part === "ALL" ? undefined : part;
+
+  useEffect(() => {
+    const pageParam = Number(searchParams.get("page"));
+    const partParam = searchParams.get("part");
+    const statusParam = searchParams.get("status");
+
+    if (Number.isInteger(pageParam) && pageParam >= 0) {
+      setPage(pageParam);
+    }
+
+    if (
+      partParam === "ALL" ||
+      partParam === "FRONTEND" ||
+      partParam === "BACKEND" ||
+      partParam === "AI_ML" ||
+      partParam === "PM_DESIGN"
+    ) {
+      setPart(partParam);
+    }
+
+    if (
+      statusParam === "ALL" ||
+      statusParam === "DRAFT" ||
+      statusParam === "SUBMITTED" ||
+      statusParam === "DOC_PASSED" ||
+      statusParam === "DOC_FAILED" ||
+      statusParam === "FINAL_PASSED" ||
+      statusParam === "FINAL_FAILED"
+    ) {
+      setStatus(statusParam);
+    }
+  }, [searchParams]);
+
+  useEffect(() => {
+    let mounted = true;
+    const loadRecruitments = async () => {
+      setIsRecruitmentsLoading(true);
+      try {
+        const response = await getRecruitments({ page: 0, size: 20 });
+        if (!mounted) return;
+        setRecruitments(response.items);
+      } catch {
+        if (!mounted) return;
+        setRecruitments([]);
+        setError("모집 목록을 불러오지 못했습니다.");
+      } finally {
+        if (!mounted) return;
+        setIsRecruitmentsLoading(false);
+      }
+    };
+
+    void loadRecruitments();
+    return () => {
+      mounted = false;
+    };
+  }, []);
+
+  useEffect(() => {
+    if (recruitments.length === 0) {
+      setSelectedRecruitmentId("");
+      setRecruitmentId(null);
+      return;
+    }
+
+    const recruitmentIdParam = Number(searchParams.get("recruitmentId"));
+    const hasQueryRecruitment =
+      Number.isInteger(recruitmentIdParam) &&
+      recruitmentIdParam > 0 &&
+      recruitments.some((item) => item.recruitmentId === recruitmentIdParam);
+
+    const initialRecruitmentId = hasQueryRecruitment
+      ? recruitmentIdParam
+      : recruitments[0].recruitmentId;
+
+    setSelectedRecruitmentId(String(initialRecruitmentId));
+    setRecruitmentId(initialRecruitmentId);
+  }, [recruitments, searchParams]);
+
+  useEffect(() => {
+    if (!recruitmentId) return;
+
+    let mounted = true;
+    const load = async () => {
+      setIsLoading(true);
+      setError("");
+      try {
+        const response = await getAdminApplications({
+          recruitmentId,
+          part: resolvedPart,
+          status: resolvedStatus,
+          page,
+          size: PAGE_SIZE,
+        });
+        if (!mounted) return;
+        setResult(response);
+      } catch {
+        if (!mounted) return;
+        setError("지원자 목록을 불러오지 못했습니다.");
+        setResult(EMPTY_PAGE);
+      } finally {
+        if (!mounted) return;
+        setIsLoading(false);
+      }
+    };
+
+    void load();
+    return () => {
+      mounted = false;
+    };
+  }, [recruitmentId, resolvedPart, resolvedStatus, page]);
+
+  const handleApplyRecruitmentId = () => {
+    const parsed = Number(selectedRecruitmentId);
+    if (!Number.isInteger(parsed) || parsed <= 0) {
+      setError("모집을 선택해 주세요.");
+      return;
+    }
+    setPage(0);
+    setError("");
+    setRecruitmentId(parsed);
+  };
+
+  const updateQuery = (next: {
+    recruitmentId?: number;
+    page?: number;
+    part?: string;
+    status?: string;
+    applicationId?: number | null;
+  }) => {
+    const params = new URLSearchParams(searchParams.toString());
+    if (next.recruitmentId) params.set("recruitmentId", String(next.recruitmentId));
+    if (typeof next.page === "number") params.set("page", String(next.page));
+    if (next.part) params.set("part", next.part);
+    if (next.status) params.set("status", next.status);
+    if (typeof next.applicationId === "number") {
+      params.set("applicationId", String(next.applicationId));
+    } else if (next.applicationId === null) {
+      params.delete("applicationId");
+    }
+    router.push(`/admin/applications?${params.toString()}`, { scroll: false });
+  };
+
+  const handleSelectApplication = (applicationId: number) => {
+    updateQuery({
+      recruitmentId: recruitmentId ?? undefined,
+      page: result.page.page,
+      part,
+      status,
+      applicationId,
+    });
+  };
+
+  const handleCloseViewer = () => {
+    updateQuery({
+      recruitmentId: recruitmentId ?? undefined,
+      page: result.page.page,
+      part,
+      status,
+      applicationId: null,
+    });
+  };
+
+  return (
+    <section className="bg-background px-4 py-10 text-white lg:px-8 lg:py-14">
+      <div className="mx-auto max-w-[1200px]">
+        <h1 className="text-[34px] font-bold tracking-[-0.02em]">Applications</h1>
+
+        {!selectedApplicationId && (
+          <div className="mt-8 grid items-start gap-4 lg:grid-cols-[220px_1fr]">
+            <aside className="rounded-2xl border border-[#3a3d45] bg-[#26282d] p-4">
+              <p className="text-xs font-semibold text-gray-4">목록</p>
+              <div className="mt-4 space-y-2">
+                <Link
+                  href="/admin/applications"
+                  className="block rounded-lg border-l-2 border-main-1 bg-[#2f323a] px-3 py-2 text-left text-[17px] text-white"
+                >
+                  1차 지원자 목록
+                </Link>
+                <Link
+                  href="/admin/interviews/candidates"
+                  className="block rounded-lg px-3 py-2 text-left text-[17px] text-gray-4"
+                >
+                  1차 합격자 목록
+                </Link>
+              </div>
+            </aside>
+
+            <div className="rounded-2xl border border-[#3a3d45] bg-[#2d3037] p-4 lg:p-6">
+              <ApplicantFilters
+                recruitments={recruitments}
+                selectedRecruitmentId={selectedRecruitmentId}
+                isRecruitmentsLoading={isRecruitmentsLoading}
+                compact={false}
+                part={part}
+                status={status}
+                onRecruitmentChange={setSelectedRecruitmentId}
+                onPartChange={(nextPart) => {
+                  setPart(nextPart);
+                  setPage(0);
+                }}
+                onStatusChange={(nextStatus) => {
+                  setStatus(nextStatus);
+                  setPage(0);
+                }}
+                onApply={handleApplyRecruitmentId}
+              />
+
+              <div className="mt-5 flex items-center justify-between">
+                <p className="text-sm text-gray-3">1차 지원자 목록</p>
+                <p className="text-xs text-gray-4">
+                  총 {result.page.totalElements.toLocaleString("ko-KR")}명
+                </p>
+              </div>
+
+              {error && <p className="mt-3 text-sm text-[#ff9ea8]">{error}</p>}
+              {!recruitmentId && !error && (
+                <p className="mt-3 text-sm text-gray-4">모집을 선택해 주세요.</p>
+              )}
+
+              <ApplicantTable
+                result={result}
+                isLoading={isLoading}
+                hasRecruitmentId={Boolean(recruitmentId)}
+                selectedApplicationId={null}
+                compact={false}
+                onSelectApplication={handleSelectApplication}
+              />
+
+              <ApplicantPagination
+                page={result.page.page}
+                totalPages={result.page.totalPages}
+                isLoading={isLoading}
+                disabled={!recruitmentId}
+                pageButtonLimit={PAGE_BUTTON_LIMIT}
+                onChangePage={(nextPage) => {
+                  setPage(nextPage);
+                  updateQuery({
+                    recruitmentId: recruitmentId ?? undefined,
+                    page: nextPage,
+                    part,
+                    status,
+                    applicationId: null,
+                  });
+                }}
+              />
+            </div>
+          </div>
+        )}
+
+        {selectedApplicationId && (
+          <div className="mt-8 grid items-start gap-4 xl:grid-cols-[minmax(0,3fr)_minmax(0,7fr)]">
+            <div className="space-y-4 self-start">
+              <aside className="rounded-2xl border border-[#3a3d45] bg-[#26282d] p-4">
+                <p className="text-xs font-semibold text-gray-4">목록</p>
+                <div className="mt-4 space-y-2">
+                  <Link
+                    href="/admin/applications"
+                    className="block rounded-lg border-l-2 border-main-1 bg-[#2f323a] px-3 py-2 text-left text-[17px] text-white"
+                  >
+                    1차 지원자 목록
+                  </Link>
+                  <Link
+                    href="/admin/interviews/candidates"
+                    className="block rounded-lg px-3 py-2 text-left text-[17px] text-gray-4"
+                  >
+                    1차 합격자 목록
+                  </Link>
+                </div>
+              </aside>
+
+              <div className="rounded-2xl border border-[#3a3d45] bg-[#2d3037] p-4 lg:p-6">
+                <ApplicantFilters
+                  recruitments={recruitments}
+                  selectedRecruitmentId={selectedRecruitmentId}
+                  isRecruitmentsLoading={isRecruitmentsLoading}
+                  compact
+                  part={part}
+                  status={status}
+                  onRecruitmentChange={setSelectedRecruitmentId}
+                  onPartChange={(nextPart) => {
+                    setPart(nextPart);
+                    setPage(0);
+                  }}
+                  onStatusChange={(nextStatus) => {
+                    setStatus(nextStatus);
+                    setPage(0);
+                  }}
+                  onApply={handleApplyRecruitmentId}
+                />
+
+                <div className="mt-5 flex items-center justify-between">
+                  <p className="text-sm text-gray-3">1차 지원자 목록</p>
+                  <p className="text-xs text-gray-4">
+                    총 {result.page.totalElements.toLocaleString("ko-KR")}명
+                  </p>
+                </div>
+
+                {error && <p className="mt-3 text-sm text-[#ff9ea8]">{error}</p>}
+                {!recruitmentId && !error && (
+                  <p className="mt-3 text-sm text-gray-4">모집을 선택해 주세요.</p>
+                )}
+
+                <ApplicantTable
+                  result={result}
+                  isLoading={isLoading}
+                  hasRecruitmentId={Boolean(recruitmentId)}
+                  selectedApplicationId={selectedApplicationId}
+                  compact
+                  onSelectApplication={handleSelectApplication}
+                />
+
+                <ApplicantPagination
+                  page={result.page.page}
+                  totalPages={result.page.totalPages}
+                  isLoading={isLoading}
+                  disabled={!recruitmentId}
+                  pageButtonLimit={PAGE_BUTTON_LIMIT}
+                  onChangePage={(nextPage) => {
+                    setPage(nextPage);
+                    updateQuery({
+                      recruitmentId: recruitmentId ?? undefined,
+                      page: nextPage,
+                      part,
+                      status,
+                      applicationId: selectedApplicationId,
+                    });
+                  }}
+                />
+              </div>
+            </div>
+
+            <div className="self-start">
+              <ApplicationDetailPage
+                applicationId={selectedApplicationId}
+                embedded
+                onClose={handleCloseViewer}
+              />
+            </div>
+          </div>
+        )}
+      </div>
+    </section>
+  );
+}

--- a/features/admin/components/ApplicantFilters.tsx
+++ b/features/admin/components/ApplicantFilters.tsx
@@ -1,0 +1,135 @@
+import type {
+  AdminApplicationStatus,
+  AdminApplyPart,
+  AdminRecruitmentListItem,
+} from "../type";
+
+const PART_OPTIONS: Array<{ label: string; value: "ALL" | AdminApplyPart }> = [
+  { label: "전체 파트", value: "ALL" },
+  { label: "FRONTEND", value: "FRONTEND" },
+  { label: "BACKEND", value: "BACKEND" },
+  { label: "AI/ML", value: "AI_ML" },
+  { label: "PM/DESIGN", value: "PM_DESIGN" },
+];
+
+const STATUS_OPTIONS: Array<{
+  label: string;
+  value: "ALL" | AdminApplicationStatus;
+}> = [
+  { label: "전체 상태", value: "ALL" },
+  { label: "제출 완료", value: "SUBMITTED" },
+  { label: "서류 합격", value: "DOC_PASSED" },
+  { label: "서류 불합격", value: "DOC_FAILED" },
+  { label: "최종 합격", value: "FINAL_PASSED" },
+  { label: "최종 불합격", value: "FINAL_FAILED" },
+  { label: "임시 저장", value: "DRAFT" },
+];
+
+type ApplicantFiltersProps = {
+  recruitments: AdminRecruitmentListItem[];
+  selectedRecruitmentId: string;
+  isRecruitmentsLoading: boolean;
+  compact?: boolean;
+  part?: "ALL" | AdminApplyPart;
+  status?: "ALL" | AdminApplicationStatus;
+  onRecruitmentChange: (value: string) => void;
+  onPartChange?: (value: "ALL" | AdminApplyPart) => void;
+  onStatusChange?: (value: "ALL" | AdminApplicationStatus) => void;
+  onApply: () => void;
+};
+
+export default function ApplicantFilters({
+  recruitments,
+  selectedRecruitmentId,
+  isRecruitmentsLoading,
+  compact = false,
+  part,
+  status,
+  onRecruitmentChange,
+  onPartChange,
+  onStatusChange,
+  onApply,
+}: ApplicantFiltersProps) {
+  const showExtendedFilters = Boolean(
+    !compact && onPartChange && onStatusChange && part && status,
+  );
+
+  return (
+    <div
+      className={`grid gap-2 ${
+        showExtendedFilters
+          ? compact
+            ? "lg:grid-cols-[1fr_170px_170px_auto]"
+            : "lg:grid-cols-[1fr_220px_220px_auto]"
+          : compact
+            ? "lg:grid-cols-[1fr_auto]"
+            : "lg:grid-cols-[1fr_auto]"
+      }`}
+    >
+      <select
+        value={selectedRecruitmentId}
+        onChange={(event) => onRecruitmentChange(event.target.value)}
+        disabled={isRecruitmentsLoading || recruitments.length === 0}
+        className={`rounded-lg border border-[#535968] bg-[#3a3f4d] px-3 text-white outline-none focus:border-main-1 disabled:opacity-60 ${
+          compact ? "h-10 text-xs" : "h-11 text-sm"
+        }`}
+      >
+        {isRecruitmentsLoading && <option value="">모집 목록 불러오는 중...</option>}
+        {!isRecruitmentsLoading && recruitments.length === 0 && (
+          <option value="">모집 목록 없음</option>
+        )}
+        {!isRecruitmentsLoading &&
+          recruitments.map((item) => (
+            <option key={item.recruitmentId} value={item.recruitmentId}>
+              {`[${item.generation}기] ${item.title} (#${item.recruitmentId})`}
+            </option>
+          ))}
+      </select>
+
+      {showExtendedFilters && (
+        <select
+          value={part}
+          onChange={(event) => onPartChange?.(event.target.value as "ALL" | AdminApplyPart)}
+          className={`rounded-lg border border-[#535968] bg-[#3a3f4d] px-3 text-white outline-none focus:border-main-1 ${
+            compact ? "h-10 text-xs" : "h-11 text-sm"
+          }`}
+        >
+          {PART_OPTIONS.map((option) => (
+            <option key={option.value} value={option.value}>
+              {option.label}
+            </option>
+          ))}
+        </select>
+      )}
+
+      {showExtendedFilters && (
+        <select
+          value={status}
+          onChange={(event) =>
+            onStatusChange?.(event.target.value as "ALL" | AdminApplicationStatus)
+          }
+          className={`rounded-lg border border-[#535968] bg-[#3a3f4d] px-3 text-white outline-none focus:border-main-1 ${
+            compact ? "h-10 text-xs" : "h-11 text-sm"
+          }`}
+        >
+          {STATUS_OPTIONS.map((option) => (
+            <option key={option.value} value={option.value}>
+              {option.label}
+            </option>
+          ))}
+        </select>
+      )}
+
+      <button
+        type="button"
+        onClick={onApply}
+        disabled={!selectedRecruitmentId}
+        className={`rounded-lg bg-main-1 font-semibold disabled:opacity-60 ${
+          compact ? "h-10 px-4 text-xs" : "h-11 px-5 text-sm"
+        }`}
+      >
+        조회
+      </button>
+    </div>
+  );
+}

--- a/features/admin/components/ApplicantPagination.tsx
+++ b/features/admin/components/ApplicantPagination.tsx
@@ -1,0 +1,65 @@
+type ApplicantPaginationProps = {
+  page: number;
+  totalPages: number;
+  isLoading: boolean;
+  disabled: boolean;
+  pageButtonLimit: number;
+  onChangePage: (nextPage: number) => void;
+};
+
+export default function ApplicantPagination({
+  page,
+  totalPages,
+  isLoading,
+  disabled,
+  pageButtonLimit,
+  onChangePage,
+}: ApplicantPaginationProps) {
+  const pageGroupStart = Math.floor(page / pageButtonLimit) * pageButtonLimit;
+  const pageGroupEnd = Math.min(pageGroupStart + pageButtonLimit, totalPages);
+  const visiblePages = Array.from(
+    { length: Math.max(pageGroupEnd - pageGroupStart, 0) },
+    (_, index) => pageGroupStart + index,
+  );
+  const canPrevGroup = pageGroupStart > 0;
+  const canNextGroup = pageGroupEnd < totalPages;
+
+  return (
+    <div className="mt-4 flex items-center justify-end gap-2">
+      <button
+        type="button"
+        disabled={!canPrevGroup || isLoading || disabled}
+        onClick={() => onChangePage(Math.max(pageGroupStart - pageButtonLimit, 0))}
+        className="h-9 rounded-md border border-[#565d6d] px-3 text-sm disabled:opacity-50"
+      >
+        이전
+      </button>
+
+      {visiblePages.map((pageIndex) => (
+        <button
+          key={pageIndex}
+          type="button"
+          onClick={() => onChangePage(pageIndex)}
+          disabled={isLoading || disabled}
+          className={`h-9 min-w-9 rounded-md border px-2 text-sm disabled:opacity-50 ${
+            pageIndex === page
+              ? "border-main-1 bg-main-1 text-white"
+              : "border-[#565d6d] text-gray-3"
+          }`}
+        >
+          {pageIndex + 1}
+        </button>
+      ))}
+
+      <button
+        type="button"
+        disabled={!canNextGroup || isLoading || disabled}
+        onClick={() => onChangePage(pageGroupEnd)}
+        className="h-9 rounded-md border border-[#565d6d] px-3 text-sm disabled:opacity-50"
+      >
+        다음
+      </button>
+    </div>
+  );
+}
+

--- a/features/admin/components/ApplicantTable.tsx
+++ b/features/admin/components/ApplicantTable.tsx
@@ -1,0 +1,116 @@
+import type { AdminApplicationListResponse } from "../type";
+
+function formatPart(value: string) {
+  if (value === "FRONTEND") return "프론트엔드";
+  if (value === "BACKEND") return "백엔드";
+  if (value === "AI_ML") return "AI / ML";
+  if (value === "PM_DESIGN") return "기획 / 디자인";
+  return value;
+}
+
+function formatEnrollment(value: string) {
+  const upper = value.toUpperCase();
+  if (upper === "ENROLLED") return "재학";
+  if (upper === "LEAVE") return "휴학";
+  if (upper === "GRADUATED") return "졸업";
+  return value;
+}
+
+function formatDateTime(value: string) {
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return "-";
+
+  return new Intl.DateTimeFormat("ko-KR", {
+    year: "2-digit",
+    month: "2-digit",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+    hour12: false,
+    timeZone: "Asia/Seoul",
+  }).format(date);
+}
+
+type ApplicantTableProps = {
+  result: AdminApplicationListResponse;
+  isLoading: boolean;
+  hasRecruitmentId: boolean;
+  selectedApplicationId?: number | null;
+  compact?: boolean;
+  onSelectApplication?: (applicationId: number) => void;
+};
+
+export default function ApplicantTable({
+  result,
+  isLoading,
+  hasRecruitmentId,
+  selectedApplicationId,
+  compact = false,
+  onSelectApplication,
+}: ApplicantTableProps) {
+  const columnCount = compact ? 3 : 7;
+
+  return (
+    <div className="mt-4 overflow-hidden rounded-xl border border-[#4a4f5b]">
+      <table className="w-full table-fixed text-center text-sm">
+        <thead className="bg-[#343843] text-gray-2">
+          <tr className="[&>th]:px-2 [&>th]:py-3">
+            {!compact && <th className="w-[70px]">No.</th>}
+            {!compact && <th>학과</th>}
+            <th className="w-[90px]">학번</th>
+            <th className="w-[140px]">파트</th>
+            {!compact && <th className="w-[120px]">학적</th>}
+            {!compact && <th className="w-[180px]">지원일시</th>}
+            <th className="w-[90px]">점수</th>
+          </tr>
+        </thead>
+        <tbody className="bg-[#2d3037] text-gray-1">
+          {isLoading && (
+            <tr>
+              <td colSpan={columnCount} className="px-3 py-12 text-gray-4">
+                불러오는 중...
+              </td>
+            </tr>
+          )}
+
+          {!isLoading && result.items.length === 0 && hasRecruitmentId && (
+            <tr>
+              <td colSpan={columnCount} className="px-3 py-12 text-gray-4">
+                조회된 지원자가 없습니다.
+              </td>
+            </tr>
+          )}
+
+          {!isLoading &&
+            result.items.map((item, index) => (
+              <tr
+                key={item.applicationId}
+                onClick={() => onSelectApplication?.(item.applicationId)}
+              className={`border-t border-[#4b4f59] [&>td]:px-2 [&>td]:py-3 cursor-pointer transition-colors ${
+                  selectedApplicationId === item.applicationId
+                    ? "bg-[#3a404d]"
+                    : "hover:bg-[#3a3f49]"
+                }`}
+              >
+                {!compact && <td>{result.page.page * result.page.size + index + 1}</td>}
+                {!compact && <td className="truncate px-3 text-left">{item.department}</td>}
+                <td>{item.studentNoPrefix}</td>
+                <td>{formatPart(item.applyPart)}</td>
+                {!compact && (
+                  <td>
+                    {item.grade}학년 {formatEnrollment(item.enrollment)}
+                  </td>
+                )}
+                {!compact && <td>{formatDateTime(item.submittedAt)}</td>}
+                <td>
+                  {typeof item.docAvgScore === "number"
+                    ? item.docAvgScore.toFixed(1)
+                    : "-"}
+                </td>
+              </tr>
+            ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/features/admin/interviews/InterviewCandidateDetailPage.tsx
+++ b/features/admin/interviews/InterviewCandidateDetailPage.tsx
@@ -1,0 +1,279 @@
+"use client";
+
+import Link from "next/link";
+import { useSearchParams } from "next/navigation";
+import { useEffect, useState } from "react";
+import {
+  getAdminInterviewCandidateDetail,
+  getAdminInterviewScoreDetail,
+  getMyAdminInterviewScore,
+  upsertMyAdminInterviewScore,
+} from "../api";
+import type { AdminApplicationDetailResponse } from "../type";
+
+type InterviewCandidateDetailPageProps = {
+  applicationId: number;
+  embedded?: boolean;
+  onClose?: () => void;
+};
+
+function formatPart(value: string) {
+  if (value === "FRONTEND") return "FRONTEND";
+  if (value === "BACKEND") return "BACKEND";
+  if (value === "AI_ML") return "AI/ML";
+  if (value === "PM_DESIGN") return "PM/DESIGN";
+  return value;
+}
+
+function formatEnrollment(value: string) {
+  const upper = value.toUpperCase();
+  if (upper === "ENROLLED") return "재학";
+  if (upper === "LEAVE") return "휴학";
+  if (upper === "GRADUATED") return "졸업";
+  return value;
+}
+
+function formatDateTime(value: string) {
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return "-";
+  return new Intl.DateTimeFormat("ko-KR", {
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+    hour12: false,
+    timeZone: "Asia/Seoul",
+  }).format(date);
+}
+
+export default function InterviewCandidateDetailPage({
+  applicationId,
+  embedded = false,
+  onClose,
+}: InterviewCandidateDetailPageProps) {
+  const searchParams = useSearchParams();
+  const listQuery = searchParams.toString();
+  const listHref = `/admin/interviews/candidates${listQuery ? `?${listQuery}` : ""}`;
+
+  const [isLoading, setIsLoading] = useState(true);
+  const [isSaving, setIsSaving] = useState(false);
+  const [error, setError] = useState("");
+  const [saveMessage, setSaveMessage] = useState("");
+  const [detail, setDetail] = useState<AdminApplicationDetailResponse | null>(
+    null,
+  );
+  const [score, setScore] = useState(0);
+  const [comment, setComment] = useState("");
+  const [average, setAverage] = useState<number | null>(null);
+  const [reviewCount, setReviewCount] = useState<number | null>(null);
+
+  useEffect(() => {
+    let mounted = true;
+    const load = async () => {
+      setIsLoading(true);
+      setError("");
+
+      try {
+        const detailResponse = await getAdminInterviewCandidateDetail(applicationId);
+        if (!mounted) return;
+        setDetail(detailResponse);
+
+        const myScore = await getMyAdminInterviewScore(applicationId);
+        if (!mounted) return;
+        setScore(myScore.score ?? 0);
+        setComment(myScore.comment ?? "");
+
+        try {
+          const scoreDetail = await getAdminInterviewScoreDetail(applicationId);
+          if (!mounted) return;
+          setAverage(scoreDetail.average);
+          setReviewCount(scoreDetail.reviewCount);
+        } catch {
+          if (!mounted) return;
+          setAverage(null);
+          setReviewCount(null);
+        }
+      } catch {
+        if (!mounted) return;
+        setError("면접 대상자 상세를 불러오지 못했습니다.");
+      } finally {
+        if (!mounted) return;
+        setIsLoading(false);
+      }
+    };
+
+    void load();
+    return () => {
+      mounted = false;
+    };
+  }, [applicationId]);
+
+  const handleSave = async () => {
+    if (!detail || isSaving) return;
+    setIsSaving(true);
+    setSaveMessage("");
+    setError("");
+    try {
+      await upsertMyAdminInterviewScore(applicationId, {
+        score,
+        comment: comment.trim(),
+      });
+      setSaveMessage("면접 점수를 저장했습니다.");
+    } catch {
+      setError("면접 점수 저장에 실패했습니다.");
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  const detailBody = (
+    <div className={`${embedded ? "" : "mt-6"} rounded-2xl bg-[#323640] p-6 lg:p-8`}>
+      {isLoading && <p className="text-sm text-gray-3">로딩 중...</p>}
+      {!isLoading && error && <p className="text-sm text-[#ff9ea8]">{error}</p>}
+
+      {!isLoading && detail && (
+        <>
+          <h2 className="text-[36px] font-bold lg:text-[44px]">
+            {formatPart(detail.applyPart)}
+          </h2>
+
+          <dl className="mt-6 grid grid-cols-[110px_1fr] gap-y-2 text-sm text-gray-3 lg:max-w-[520px]">
+            <dt className="font-semibold text-gray-2">학과</dt>
+            <dd>{detail.applicant.department}</dd>
+            <dt className="font-semibold text-gray-2">학번</dt>
+            <dd>{detail.applicant.studentNoPrefix}학번</dd>
+            <dt className="font-semibold text-gray-2">학적상태</dt>
+            <dd>
+              {detail.applicant.grade}학년 {formatEnrollment(detail.applicant.enrollment)}
+            </dd>
+            <dt className="font-semibold text-gray-2">지원일시</dt>
+            <dd>{formatDateTime(detail.submittedAt)}</dd>
+          </dl>
+
+          {reviewCount !== null && average !== null && (
+            <p className="mt-4 text-sm text-gray-4">
+              평가 {reviewCount}명 평균 점수 {average.toFixed(2)}
+            </p>
+          )}
+
+          <div className="my-8 h-px bg-[#606673]" />
+
+          <div className="space-y-8">
+            {detail.answers.map((item, index) => (
+              <article key={item.questionId} className="space-y-3">
+                <h3 className="text-lg font-semibold">
+                  문항 {index + 1}. {item.content}
+                </h3>
+                <p className="whitespace-pre-wrap rounded-lg bg-[#404654] p-4 text-sm text-gray-2">
+                  {item.answer}
+                </p>
+              </article>
+            ))}
+          </div>
+
+          <div className="my-8 h-px bg-[#606673]" />
+
+          <div className="mb-8 flex items-center gap-3">
+            <label className="text-sm text-gray-3">면접 점수</label>
+            <input
+              type="number"
+              min={0}
+              step={1}
+              value={score}
+              onChange={(event) => {
+                const numeric = Number(event.target.value);
+                setScore(Number.isFinite(numeric) ? Math.max(0, numeric) : 0);
+              }}
+              className="h-9 w-28 rounded-md border border-[#666d7d] bg-[#505767] px-3 text-sm outline-none focus:border-main-1"
+            />
+          </div>
+
+          <div className="space-y-3">
+            <h3 className="text-[22px] font-semibold">총평 코멘트</h3>
+            <textarea
+              value={comment}
+              onChange={(event) => setComment(event.target.value)}
+              rows={5}
+              placeholder="코멘트를 입력해 주세요."
+              className="w-full resize-none rounded-xl border border-[#62697A] bg-[#4C5262] p-4 text-sm text-white placeholder:text-gray-4 outline-none focus:border-main-1"
+            />
+          </div>
+
+          <div className="mt-8 flex justify-center">
+            <button
+              type="button"
+              onClick={handleSave}
+              disabled={isSaving}
+              className="rounded-lg bg-main-1 px-10 py-3 text-sm font-semibold disabled:opacity-60"
+            >
+              {isSaving ? "저장 중..." : "확인"}
+            </button>
+          </div>
+
+          {saveMessage && (
+            <p className="mt-3 text-center text-sm text-[#8fd3ff]">{saveMessage}</p>
+          )}
+        </>
+      )}
+    </div>
+  );
+
+  if (embedded) {
+    return (
+      <div className="rounded-2xl border border-[#3a3d45] bg-[#2d3037] p-4">
+        <div className="mb-3 flex items-center justify-between">
+          <h3 className="text-sm font-semibold text-gray-2">1차 합격 상세</h3>
+          {onClose && (
+            <button
+              type="button"
+              onClick={onClose}
+              className="rounded-md bg-[#454c5a] px-3 py-1.5 text-xs"
+            >
+              닫기
+            </button>
+          )}
+        </div>
+        {detailBody}
+      </div>
+    );
+  }
+
+  return (
+    <section className="bg-background px-4 py-10 text-white lg:px-8 lg:py-14">
+      <div className="mx-auto max-w-[1200px]">
+        <div className="grid gap-4 lg:grid-cols-[220px_1fr]">
+          <aside className="rounded-2xl border border-[#3a3d45] bg-[#26282d] p-4">
+            <p className="text-xs font-semibold text-gray-4">목록</p>
+            <div className="mt-4 space-y-2">
+              <Link
+                href="/admin/applications"
+                className="block rounded-lg px-3 py-2 text-left text-[17px] text-gray-4"
+              >
+                서류 지원서 목록
+              </Link>
+              <Link
+                href="/admin/interviews/candidates"
+                className="block rounded-lg border-l-2 border-main-1 bg-[#2f323a] px-3 py-2 text-left text-[17px] text-white"
+              >
+                면접 대상자 목록
+              </Link>
+            </div>
+          </aside>
+
+          <div className="rounded-2xl border border-[#3a3d45] bg-[#2d3037] p-4 lg:p-6">
+            <div className="flex justify-end">
+              <Link
+                href={listHref}
+                className="rounded-lg bg-main-1 px-6 py-3 text-sm font-semibold"
+              >
+                목록 보기
+              </Link>
+            </div>
+            {detailBody}
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/features/admin/interviews/InterviewCandidatesListPage.tsx
+++ b/features/admin/interviews/InterviewCandidatesListPage.tsx
@@ -1,0 +1,371 @@
+﻿"use client";
+
+import Link from "next/link";
+import { useEffect, useMemo, useState } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
+import { getAdminInterviewCandidates, getRecruitments } from "../api";
+import type {
+  AdminApplicationListResponse,
+  AdminRecruitmentListItem,
+} from "../type";
+import ApplicantPagination from "../components/ApplicantPagination";
+import ApplicantTable from "../components/ApplicantTable";
+import InterviewCandidateDetailPage from "./InterviewCandidateDetailPage";
+
+const PAGE_SIZE = 12;
+const PAGE_BUTTON_LIMIT = 10;
+
+const EMPTY_PAGE: AdminApplicationListResponse = {
+  items: [],
+  page: {
+    page: 0,
+    size: PAGE_SIZE,
+    totalElements: 0,
+    totalPages: 0,
+  },
+};
+
+export default function InterviewCandidatesListPage() {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const [recruitments, setRecruitments] = useState<AdminRecruitmentListItem[]>([]);
+  const [isRecruitmentsLoading, setIsRecruitmentsLoading] = useState(false);
+  const [selectedRecruitmentId, setSelectedRecruitmentId] = useState("");
+  const [recruitmentId, setRecruitmentId] = useState<number | null>(null);
+  const [page, setPage] = useState(0);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState("");
+  const [result, setResult] = useState<AdminApplicationListResponse>(EMPTY_PAGE);
+
+  const selectedApplicationId = useMemo(() => {
+    const parsed = Number(searchParams.get("applicationId"));
+    if (!Number.isInteger(parsed) || parsed <= 0) return null;
+    return parsed;
+  }, [searchParams]);
+
+  useEffect(() => {
+    const pageParam = Number(searchParams.get("page"));
+
+    if (Number.isInteger(pageParam) && pageParam >= 0) {
+      setPage(pageParam);
+    }
+  }, [searchParams]);
+
+  useEffect(() => {
+    let mounted = true;
+    const loadRecruitments = async () => {
+      setIsRecruitmentsLoading(true);
+      try {
+        const response = await getRecruitments({ page: 0, size: 20 });
+        if (!mounted) return;
+        setRecruitments(response.items);
+      } catch {
+        if (!mounted) return;
+        setRecruitments([]);
+        setError("모집 목록을 불러오지 못했습니다.");
+      } finally {
+        if (!mounted) return;
+        setIsRecruitmentsLoading(false);
+      }
+    };
+
+    void loadRecruitments();
+    return () => {
+      mounted = false;
+    };
+  }, []);
+
+  useEffect(() => {
+    if (recruitments.length === 0) {
+      setSelectedRecruitmentId("");
+      setRecruitmentId(null);
+      return;
+    }
+
+    const recruitmentIdParam = Number(searchParams.get("recruitmentId"));
+    const hasQueryRecruitment =
+      Number.isInteger(recruitmentIdParam) &&
+      recruitmentIdParam > 0 &&
+      recruitments.some((item) => item.recruitmentId === recruitmentIdParam);
+
+    const initialRecruitmentId = hasQueryRecruitment
+      ? recruitmentIdParam
+      : recruitments[0].recruitmentId;
+
+    setSelectedRecruitmentId(String(initialRecruitmentId));
+    setRecruitmentId(initialRecruitmentId);
+  }, [recruitments, searchParams]);
+
+  useEffect(() => {
+    if (!recruitmentId) return;
+
+    let mounted = true;
+    const load = async () => {
+      setIsLoading(true);
+      setError("");
+      try {
+        const response = await getAdminInterviewCandidates({
+          recruitmentId,
+          page,
+          size: PAGE_SIZE,
+        });
+        if (!mounted) return;
+        setResult(response);
+      } catch {
+        if (!mounted) return;
+        setError("합격자 목록을 불러오지 못했습니다.");
+        setResult(EMPTY_PAGE);
+      } finally {
+        if (!mounted) return;
+        setIsLoading(false);
+      }
+    };
+
+    void load();
+    return () => {
+      mounted = false;
+    };
+  }, [recruitmentId, page]);
+
+  const updateQuery = (next: {
+    recruitmentId?: number;
+    page?: number;
+    applicationId?: number | null;
+  }) => {
+    const params = new URLSearchParams(searchParams.toString());
+    if (next.recruitmentId) params.set("recruitmentId", String(next.recruitmentId));
+    if (typeof next.page === "number") params.set("page", String(next.page));
+    params.delete("part");
+    if (typeof next.applicationId === "number") {
+      params.set("applicationId", String(next.applicationId));
+    } else if (next.applicationId === null) {
+      params.delete("applicationId");
+    }
+    router.push(`/admin/interviews/candidates?${params.toString()}`, { scroll: false });
+  };
+
+  const handleApplyRecruitmentId = () => {
+    const parsed = Number(selectedRecruitmentId);
+    if (!Number.isInteger(parsed) || parsed <= 0) {
+      setError("모집을 선택해 주세요.");
+      return;
+    }
+    setPage(0);
+    setError("");
+    setRecruitmentId(parsed);
+  };
+
+  const handleSelectApplication = (applicationId: number) => {
+    updateQuery({
+      recruitmentId: recruitmentId ?? undefined,
+      page: result.page.page,
+      applicationId,
+    });
+  };
+
+  const handleCloseViewer = () => {
+    updateQuery({
+      recruitmentId: recruitmentId ?? undefined,
+      page: result.page.page,
+      applicationId: null,
+    });
+  };
+
+  return (
+    <section className="bg-background px-4 py-10 text-white lg:px-8 lg:py-14">
+      <div className="mx-auto max-w-[1200px]">
+        <h1 className="text-[34px] font-bold tracking-[-0.02em]">Interview Candidates</h1>
+
+        {!selectedApplicationId && (
+          <div className="mt-8 grid items-start gap-4 lg:grid-cols-[220px_1fr]">
+            <aside className="rounded-2xl border border-[#3a3d45] bg-[#26282d] p-4">
+              <p className="text-xs font-semibold text-gray-4">목록</p>
+              <div className="mt-4 space-y-2">
+                <Link
+                  href="/admin/applications"
+                  className="block rounded-lg px-3 py-2 text-left text-[17px] text-gray-4"
+                >
+                  1차 지원자 목록
+                </Link>
+                <Link
+                  href="/admin/interviews/candidates"
+                  className="block rounded-lg border-l-2 border-main-1 bg-[#2f323a] px-3 py-2 text-left text-[17px] text-white"
+                >
+                  1차 합격자 목록
+                </Link>
+              </div>
+            </aside>
+
+            <div className="rounded-2xl border border-[#3a3d45] bg-[#2d3037] p-4 lg:p-6">
+              <div className="grid gap-2 lg:grid-cols-[1fr_auto]">
+                <select
+                  value={selectedRecruitmentId}
+                  onChange={(event) => setSelectedRecruitmentId(event.target.value)}
+                  disabled={isRecruitmentsLoading || recruitments.length === 0}
+                  className="h-11 rounded-lg border border-[#535968] bg-[#3a3f4d] px-3 text-sm text-white outline-none focus:border-main-1 disabled:opacity-60"
+                >
+                  {isRecruitmentsLoading && <option value="">모집 목록 불러오는 중...</option>}
+                  {!isRecruitmentsLoading && recruitments.length === 0 && (
+                    <option value="">모집 목록 없음</option>
+                  )}
+                  {!isRecruitmentsLoading &&
+                    recruitments.map((item) => (
+                      <option key={item.recruitmentId} value={item.recruitmentId}>
+                        {`[${item.generation}기] ${item.title} (#${item.recruitmentId})`}
+                      </option>
+                    ))}
+                </select>
+
+                <button
+                  type="button"
+                  onClick={handleApplyRecruitmentId}
+                  disabled={!selectedRecruitmentId}
+                  className="h-11 rounded-lg bg-main-1 px-5 text-sm font-semibold disabled:opacity-60"
+                >
+                  조회
+                </button>
+              </div>
+
+              <div className="mt-5 flex items-center justify-between">
+                <p className="text-sm text-gray-3">1차 합격자 목록</p>
+                <p className="text-xs text-gray-4">
+                  총 {result.page.totalElements.toLocaleString("ko-KR")}명
+                </p>
+              </div>
+
+              {error && <p className="mt-3 text-sm text-[#ff9ea8]">{error}</p>}
+              {!recruitmentId && !error && (
+                <p className="mt-3 text-sm text-gray-4">모집을 선택해 주세요.</p>
+              )}
+
+              <ApplicantTable
+                result={result}
+                isLoading={isLoading}
+                hasRecruitmentId={Boolean(recruitmentId)}
+                selectedApplicationId={null}
+                compact={false}
+                onSelectApplication={handleSelectApplication}
+              />
+
+              <ApplicantPagination
+                page={result.page.page}
+                totalPages={result.page.totalPages}
+                isLoading={isLoading}
+                disabled={!recruitmentId}
+                pageButtonLimit={PAGE_BUTTON_LIMIT}
+                onChangePage={(nextPage) => {
+                  setPage(nextPage);
+                  updateQuery({
+                    recruitmentId: recruitmentId ?? undefined,
+                    page: nextPage,
+                    applicationId: null,
+                  });
+                }}
+              />
+            </div>
+          </div>
+        )}
+
+        {selectedApplicationId && (
+          <div className="mt-8 grid items-start gap-4 xl:grid-cols-[minmax(0,3fr)_minmax(0,7fr)]">
+            <div className="space-y-4 self-start">
+              <aside className="rounded-2xl border border-[#3a3d45] bg-[#26282d] p-4">
+                <p className="text-xs font-semibold text-gray-4">목록</p>
+                <div className="mt-4 space-y-2">
+                  <Link
+                    href="/admin/applications"
+                    className="block rounded-lg px-3 py-2 text-left text-[17px] text-gray-4"
+                  >
+                    1차 지원자 목록
+                  </Link>
+                  <Link
+                    href="/admin/interviews/candidates"
+                    className="block rounded-lg border-l-2 border-main-1 bg-[#2f323a] px-3 py-2 text-left text-[17px] text-white"
+                  >
+                    1차 합격자 목록
+                  </Link>
+                </div>
+              </aside>
+
+              <div className="rounded-2xl border border-[#3a3d45] bg-[#2d3037] p-4 lg:p-6">
+                <div className="grid gap-2 lg:grid-cols-[1fr_auto]">
+                  <select
+                    value={selectedRecruitmentId}
+                    onChange={(event) => setSelectedRecruitmentId(event.target.value)}
+                    disabled={isRecruitmentsLoading || recruitments.length === 0}
+                    className="h-11 rounded-lg border border-[#535968] bg-[#3a3f4d] px-3 text-sm text-white outline-none focus:border-main-1 disabled:opacity-60"
+                  >
+                    {isRecruitmentsLoading && <option value="">모집 목록 불러오는 중...</option>}
+                    {!isRecruitmentsLoading && recruitments.length === 0 && (
+                      <option value="">모집 목록 없음</option>
+                    )}
+                    {!isRecruitmentsLoading &&
+                      recruitments.map((item) => (
+                        <option key={item.recruitmentId} value={item.recruitmentId}>
+                          {`[${item.generation}기] ${item.title} (#${item.recruitmentId})`}
+                        </option>
+                      ))}
+                  </select>
+
+                  <button
+                    type="button"
+                    onClick={handleApplyRecruitmentId}
+                    disabled={!selectedRecruitmentId}
+                    className="h-11 rounded-lg bg-main-1 px-5 text-sm font-semibold disabled:opacity-60"
+                  >
+                    조회
+                  </button>
+                </div>
+
+                <div className="mt-5 flex items-center justify-between">
+                  <p className="text-sm text-gray-3">1차 합격자 목록</p>
+                  <p className="text-xs text-gray-4">
+                    총 {result.page.totalElements.toLocaleString("ko-KR")}명
+                  </p>
+                </div>
+
+                {error && <p className="mt-3 text-sm text-[#ff9ea8]">{error}</p>}
+                {!recruitmentId && !error && (
+                  <p className="mt-3 text-sm text-gray-4">모집을 선택해 주세요.</p>
+                )}
+
+                <ApplicantTable
+                  result={result}
+                  isLoading={isLoading}
+                  hasRecruitmentId={Boolean(recruitmentId)}
+                  selectedApplicationId={selectedApplicationId}
+                  compact
+                  onSelectApplication={handleSelectApplication}
+                />
+
+                <ApplicantPagination
+                  page={result.page.page}
+                  totalPages={result.page.totalPages}
+                  isLoading={isLoading}
+                  disabled={!recruitmentId}
+                  pageButtonLimit={PAGE_BUTTON_LIMIT}
+                  onChangePage={(nextPage) => {
+                    setPage(nextPage);
+                    updateQuery({
+                      recruitmentId: recruitmentId ?? undefined,
+                      page: nextPage,
+                      applicationId: selectedApplicationId,
+                    });
+                  }}
+                />
+              </div>
+            </div>
+
+            <div className="self-start">
+              <InterviewCandidateDetailPage
+                applicationId={selectedApplicationId}
+                embedded
+                onClose={handleCloseViewer}
+              />
+            </div>
+          </div>
+        )}
+      </div>
+    </section>
+  );
+}


### PR DESCRIPTION
## 📎 관련 이슈
Closes #27


## 📝 작업 내용
- 지원자/합격자 목록에서 항목 클릭 시 페이지 이동 대신 우측 상세 뷰어를 로딩하도록 변경
- 상세 닫힘/열림 상태에 따라 레이아웃을 분기 적용
- 상세 닫힘: 목록과 리스트를 좌우 배치, 상세 열림: 좌측(목록+리스트) / 우측(상세) 3:7 비율 적용
- 상세 열림 시 리스트 컴팩트 모드 적용(No./학과 컬럼 숨김)
- 서류 목록 필터 정책 반영(닫힘: recruitment+파트+상태, 열림: recruitment만 노출)
- 1차 합격 목록은 recruitment 기반 필터 유지
- 관리자 상세 라우트/기존 applicants 경로 정리 및 한글 깨짐 문구 복구

## 체크리스트
- [ ] 포메팅이 적용되었습니다.

## 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)

## 💬 비고