### PR TITLE
feat: 관리자 유저 목록·상세 조회 기능 추가 및 관리자 화면 문구 정리

### DIFF
--- a/app/admin/layout.tsx
+++ b/app/admin/layout.tsx
@@ -3,8 +3,8 @@ import "@/styles/globals.css";
 import Header from "@/components/layout/Header";
 
 export const metadata: Metadata = {
-  title: "삼육멋사14기 운영페이지",
-  description: "멋쟁이사자처럼 14기 사이트",
+  title: "멋쟁이사자처럼14기 운영페이지",
+  description: "멋쟁이사자처럼 14기 관리자 페이지",
   icons: {
     icon: "/favicon.svg",
   },

--- a/app/admin/users/[loginId]/page.tsx
+++ b/app/admin/users/[loginId]/page.tsx
@@ -1,0 +1,12 @@
+import UserDetailDummyPage from "@/features/admin/users/UserDetailDummyPage";
+
+type AdminUserDetailPageProps = {
+  params: Promise<{
+    loginId: string;
+  }>;
+};
+
+export default async function AdminUserDetailPage({ params }: AdminUserDetailPageProps) {
+  const { loginId } = await params;
+  return <UserDetailDummyPage loginId={decodeURIComponent(loginId)} />;
+}

--- a/app/admin/users/page.tsx
+++ b/app/admin/users/page.tsx
@@ -1,0 +1,5 @@
+import UsersDummyPage from "@/features/admin/users/UsersDummyPage";
+
+export default function AdminUsersPage() {
+  return <UsersDummyPage />;
+}

--- a/features/admin/AdminEntryPage.tsx
+++ b/features/admin/AdminEntryPage.tsx
@@ -1,4 +1,4 @@
-"use client"
+﻿"use client"
 
 import Image from "next/image"
 import Link from "next/link"
@@ -14,17 +14,17 @@ type EntryItem = {
 const ENTRY_ITEMS: EntryItem[] = [
     {
         title: "멋사 SYU 14TH\n지원자 관리",
-        description: "멋사 SYU 14TH 아기사자 지원 내역을 확인하고\n합격/불합격 처리를 해요.",
-        href: "/admin/applicants",
+        description: "멋사 SYU 14TH 서류 지원자 목록을 확인하고\n합격/불합격 처리를 해요.",
+        href: "/admin/applications",
     },
     {
-        title: "멋사 SYU 14TH\n아기사자 관리",
-        description: "아기사자의 출결과 과제를 관리할 수 있어요.\n커뮤니티와 공지사항도 함께 관리해요.",
-        href: "/admin/baby-lions",
+        title: "멋사 SYU 14TH\n면접자 관리",
+        description: "면접 대상자 출결과 과제를 관리하고\n커뮤니티와 공지사항 운영을 진행해요.",
+        href: "/admin/interviews/candidates",
     },
     {
         title: "멋사 SYU 14TH\n운영진 주요업무",
-        description: "운영진의 주요 업무를 수행해요.\n아기사자용/스태프용 페이지를 관리해요.",
+        description: "운영진의 주요 업무를 수행해요.\n지원자와 스태프 운영 페이지를 관리해요.",
         href: "/admin/staff-tasks",
     },
 ]

--- a/features/admin/api.ts
+++ b/features/admin/api.ts
@@ -1,0 +1,197 @@
+﻿import { apiClient } from "@/lib/axios";
+import type {
+  AdminApplicationDetailResponse,
+  AdminApplicationListQuery,
+  AdminApplicationListResponse,
+  AdminDocumentFinalizeRequest,
+  AdminDocumentFinalizeResponse,
+  AdminFinalFinalizeRequest,
+  AdminFinalFinalizeResponse,
+  AdminFinalPendingDecisionRequest,
+  AdminFinalPendingDecisionResponse,
+  AdminDocumentPendingDecisionRequest,
+  AdminDocumentPendingDecisionResponse,
+  AdminDocumentScoresDetailResponse,
+  AdminInterviewCandidateDetailResponse,
+  AdminInterviewCandidateListQuery,
+  AdminInterviewCandidateListResponse,
+  AdminInterviewScoreDetailResponse,
+  AdminRecruitmentListQuery,
+  AdminRecruitmentListResponse,
+  AdminUserDetailResponse,
+  AdminUsersListResponse,
+  AdminMyInterviewScoreResponse,
+  AdminMyDocumentScoreResponse,
+  UpsertAdminMyInterviewScoreRequest,
+  UpsertAdminMyInterviewScoreResponse,
+  UpsertAdminMyDocumentScoreRequest,
+  UpsertAdminMyDocumentScoreResponse,
+} from "./type";
+
+export async function getAdminApplications(
+  query: AdminApplicationListQuery,
+): Promise<AdminApplicationListResponse> {
+  const response = await apiClient.get<AdminApplicationListResponse>(
+    "/admin/applications",
+    {
+      params: query,
+    },
+  );
+
+  return response.data;
+}
+
+export async function getAdminApplicationDetail(
+  applicationId: number,
+): Promise<AdminApplicationDetailResponse> {
+  const response = await apiClient.get<AdminApplicationDetailResponse>(
+    `/admin/applications/${applicationId}`,
+  );
+
+  return response.data;
+}
+
+export async function getAdminInterviewCandidates(
+  query: AdminInterviewCandidateListQuery,
+): Promise<AdminInterviewCandidateListResponse> {
+  const response = await apiClient.get<AdminInterviewCandidateListResponse>(
+    "/admin/interviews/candidates",
+    {
+      params: query,
+    },
+  );
+
+  return response.data;
+}
+
+export async function getAdminInterviewCandidateDetail(
+  applicationId: number,
+): Promise<AdminInterviewCandidateDetailResponse> {
+  const response = await apiClient.get<AdminInterviewCandidateDetailResponse>(
+    `/admin/interviews/candidates/${applicationId}`,
+  );
+
+  return response.data;
+}
+
+export async function getMyAdminDocumentScores(
+  applicationId: number,
+): Promise<AdminMyDocumentScoreResponse> {
+  const response = await apiClient.get<AdminMyDocumentScoreResponse>(
+    `/admin/applications/${applicationId}/document-scores/me`,
+  );
+  return response.data;
+}
+
+export async function upsertMyAdminDocumentScores(
+  applicationId: number,
+  payload: UpsertAdminMyDocumentScoreRequest,
+): Promise<UpsertAdminMyDocumentScoreResponse> {
+  const response = await apiClient.put<UpsertAdminMyDocumentScoreResponse>(
+    `/admin/applications/${applicationId}/document-scores/me`,
+    payload,
+  );
+  return response.data;
+}
+
+export async function getAdminDocumentScoresDetail(
+  applicationId: number,
+): Promise<AdminDocumentScoresDetailResponse> {
+  const response = await apiClient.get<AdminDocumentScoresDetailResponse>(
+    `/admin/applications/${applicationId}/document-scores`,
+  );
+  return response.data;
+}
+
+export async function postAdminDocumentPendingDecision(
+  payload: AdminDocumentPendingDecisionRequest,
+): Promise<AdminDocumentPendingDecisionResponse> {
+  const response = await apiClient.post<AdminDocumentPendingDecisionResponse>(
+    "/admin/document/pending-decision",
+    payload,
+  );
+  return response.data;
+}
+
+export async function postAdminDocumentFinalize(
+  payload: AdminDocumentFinalizeRequest,
+): Promise<AdminDocumentFinalizeResponse> {
+  const response = await apiClient.post<AdminDocumentFinalizeResponse>(
+    "/admin/document/finalize",
+    payload,
+  );
+  return response.data;
+}
+
+export async function getMyAdminInterviewScore(
+  applicationId: number,
+): Promise<AdminMyInterviewScoreResponse> {
+  const response = await apiClient.get<AdminMyInterviewScoreResponse>(
+    `/admin/interviews/${applicationId}/score/me`,
+  );
+  return response.data;
+}
+
+export async function upsertMyAdminInterviewScore(
+  applicationId: number,
+  payload: UpsertAdminMyInterviewScoreRequest,
+): Promise<UpsertAdminMyInterviewScoreResponse> {
+  const response = await apiClient.put<UpsertAdminMyInterviewScoreResponse>(
+    `/admin/interviews/${applicationId}/score/me`,
+    payload,
+  );
+  return response.data;
+}
+
+export async function getAdminInterviewScoreDetail(
+  applicationId: number,
+): Promise<AdminInterviewScoreDetailResponse> {
+  const response = await apiClient.get<AdminInterviewScoreDetailResponse>(
+    `/admin/interviews/${applicationId}/score`,
+  );
+  return response.data;
+}
+
+export async function postAdminFinalPendingDecision(
+  payload: AdminFinalPendingDecisionRequest,
+): Promise<AdminFinalPendingDecisionResponse> {
+  const response = await apiClient.post<AdminFinalPendingDecisionResponse>(
+    "/admin/final/pending-decision",
+    payload,
+  );
+  return response.data;
+}
+
+export async function postAdminFinalFinalize(
+  payload: AdminFinalFinalizeRequest,
+): Promise<AdminFinalFinalizeResponse> {
+  const response = await apiClient.post<AdminFinalFinalizeResponse>(
+    "/admin/final/finalize",
+    payload,
+  );
+  return response.data;
+}
+
+export async function getAdminUsers(): Promise<AdminUsersListResponse> {
+  const response = await apiClient.get<AdminUsersListResponse>("/admin/users");
+  return response.data;
+}
+
+export async function getRecruitments(
+  query: AdminRecruitmentListQuery = {},
+): Promise<AdminRecruitmentListResponse> {
+  const response = await apiClient.get<AdminRecruitmentListResponse>(
+    "/recruitments",
+    { params: query },
+  );
+  return response.data;
+}
+
+export async function getAdminUserDetail(
+  loginId: string,
+): Promise<AdminUserDetailResponse> {
+  const response = await apiClient.get<AdminUserDetailResponse>(
+    `/admin/users/${encodeURIComponent(loginId)}`,
+  );
+  return response.data;
+}

--- a/features/admin/type.ts
+++ b/features/admin/type.ts
@@ -1,0 +1,247 @@
+﻿export type AdminApplyPart = "FRONTEND" | "BACKEND" | "AI_ML" | "PM_DESIGN";
+
+export type AdminApplicationStatus =
+  | "DRAFT"
+  | "SUBMITTED"
+  | "DOC_PASSED"
+  | "DOC_FAILED"
+  | "FINAL_PASSED"
+  | "FINAL_FAILED";
+
+export type AdminApplicationListItem = {
+  applicationId: number;
+  applyPart: AdminApplyPart | string;
+  status: AdminApplicationStatus | string;
+  submittedAt: string;
+  docAvgScore: number | null;
+  department: string;
+  studentNoPrefix: string;
+  grade: number;
+  enrollment: string;
+};
+
+export type AdminApplicationListResponse = {
+  items: AdminApplicationListItem[];
+  page: {
+    page: number;
+    size: number;
+    totalElements: number;
+    totalPages: number;
+  };
+};
+
+export type AdminApplicationListQuery = {
+  recruitmentId: number;
+  part?: AdminApplyPart;
+  status?: AdminApplicationStatus;
+  page?: number;
+  size?: number;
+  sort?: string;
+};
+
+export type AdminInterviewCandidateListQuery = {
+  recruitmentId: number;
+  part?: AdminApplyPart;
+  page?: number;
+  size?: number;
+  sort?: string;
+};
+
+export type AdminApplicationAnswer = {
+  questionId: number;
+  content: string;
+  answer: string;
+};
+
+export type AdminApplicationFile = {
+  fileId: number;
+  originalName: string;
+  size: number;
+  url: string;
+};
+
+export type AdminApplicationDetailResponse = {
+  applicationId: number;
+  recruitmentId: number;
+  applyPart: AdminApplyPart | string;
+  status: AdminApplicationStatus | string;
+  submittedAt: string;
+  applicant: {
+    department: string;
+    studentNoPrefix: string;
+    grade: number;
+    enrollment: string;
+  };
+  answers: AdminApplicationAnswer[];
+  files: AdminApplicationFile[];
+  docAvgScore: number | null;
+};
+
+export type AdminInterviewCandidateListResponse = AdminApplicationListResponse;
+export type AdminInterviewCandidateDetailResponse = AdminApplicationDetailResponse;
+
+export type AdminDocumentScoreItem = {
+  questionId: number;
+  score: number;
+};
+
+export type AdminMyDocumentScoreResponse = {
+  exists: boolean;
+  scores: AdminDocumentScoreItem[];
+  comment: string;
+};
+
+export type UpsertAdminMyDocumentScoreRequest = {
+  scores: AdminDocumentScoreItem[];
+  comment: string | null;
+};
+
+export type UpsertAdminMyDocumentScoreResponse = {
+  ok: boolean;
+};
+
+export type AdminDocumentScoreReview = {
+  reviewer: {
+    profileImageUrl: string;
+    name: string;
+    part: string;
+  };
+  scores: AdminDocumentScoreItem[];
+  total: number;
+  comment: string;
+};
+
+export type AdminDocumentScoresDetailResponse = {
+  applicationId: number;
+  average: number;
+  reviewCount: number;
+  canViewOthersScores: boolean;
+  reviews: AdminDocumentScoreReview[];
+};
+
+export type AdminDocumentPendingDecisionRequest = {
+  recruitmentId: number;
+  passIds: number[];
+  failIds: number[];
+};
+
+export type AdminDocumentPendingDecisionResponse = {
+  ok: boolean;
+};
+
+export type AdminDocumentFinalizeRequest = {
+  recruitmentId: number;
+};
+
+export type AdminDocumentFinalizeResponse = {
+  ok: boolean;
+  finalizedCount: number;
+};
+
+export type AdminMyInterviewScoreResponse = {
+  exists: boolean;
+  score: number;
+  comment: string;
+};
+
+export type UpsertAdminMyInterviewScoreRequest = {
+  score: number;
+  comment: string;
+};
+
+export type UpsertAdminMyInterviewScoreResponse = {
+  ok: boolean;
+};
+
+export type AdminInterviewScoreReview = {
+  reviewerUserUuid: string;
+  score: number;
+  comment: string;
+};
+
+export type AdminInterviewScoreDetailResponse = {
+  applicationId: number;
+  average: number;
+  reviewCount: number;
+  canViewOthersScores: boolean;
+  reviews: AdminInterviewScoreReview[];
+};
+
+export type AdminFinalPendingDecisionRequest = {
+  recruitmentId: number;
+  passIds: number[];
+  failIds: number[];
+};
+
+export type AdminFinalPendingDecisionResponse = {
+  ok: boolean;
+};
+
+export type AdminFinalFinalizeRequest = {
+  recruitmentId: number;
+};
+
+export type AdminFinalFinalizeResponse = {
+  ok: boolean;
+  finalizedCount: number;
+};
+
+export type AdminUserListItem = {
+  profileImageUrl: string;
+  loginId: string;
+  name: string;
+  department: string;
+  studentNo: string;
+  level: string;
+};
+
+export type AdminUsersListResponse = {
+  totalCount: number;
+  users: AdminUserListItem[];
+};
+
+export type AdminUserDetail = {
+  loginId: string;
+  name: string;
+  department: string;
+  studentNo: string;
+  grade: number;
+  enrollmentStatus: string;
+  birthDate: string;
+  phone: string;
+  withdrawalStatus: string;
+  email: string;
+  generation: number;
+  level: string;
+  track: string;
+  position: string;
+};
+
+export type AdminUserDetailResponse = {
+  user: AdminUserDetail;
+};
+
+export type AdminRecruitmentListItem = {
+  recruitmentId: number;
+  generation: number;
+  title: string;
+  phaseType: string;
+  docStartAt: string;
+  docEndAt: string;
+};
+
+export type AdminRecruitmentListResponse = {
+  items: AdminRecruitmentListItem[];
+  page: {
+    page: number;
+    size: number;
+    totalElements: number;
+    totalPages: number;
+  };
+};
+
+export type AdminRecruitmentListQuery = {
+  page?: number;
+  size?: number;
+  sort?: string;
+};

--- a/features/admin/users/UserDetailDummyPage.tsx
+++ b/features/admin/users/UserDetailDummyPage.tsx
@@ -1,0 +1,102 @@
+﻿"use client";
+
+import Link from "next/link";
+import { useEffect, useState } from "react";
+import { getAdminUserDetail } from "../api";
+import type { AdminUserDetail } from "../type";
+
+type UserDetailDummyPageProps = {
+  loginId: string;
+};
+
+function Row({ label, value }: { label: string; value: string | number }) {
+  return (
+    <div className="grid grid-cols-[160px_1fr] gap-2 border-t border-[#3a3d45] px-4 py-3 text-sm">
+      <dt className="text-gray-4">{label}</dt>
+      <dd>{value}</dd>
+    </div>
+  );
+}
+
+export default function UserDetailDummyPage({ loginId }: UserDetailDummyPageProps) {
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState("");
+  const [user, setUser] = useState<AdminUserDetail | null>(null);
+
+  useEffect(() => {
+    let mounted = true;
+    const load = async () => {
+      setIsLoading(true);
+      setError("");
+      setUser(null);
+
+      try {
+        const response = await getAdminUserDetail(loginId);
+        if (!mounted) return;
+        setUser(response.user);
+      } catch {
+        if (!mounted) return;
+        setError("유저 상세 정보를 불러오지 못했습니다. 권한 또는 loginId를 확인해 주세요.");
+      } finally {
+        if (!mounted) return;
+        setIsLoading(false);
+      }
+    };
+
+    void load();
+    return () => {
+      mounted = false;
+    };
+  }, [loginId]);
+
+  return (
+    <section className="bg-background px-4 py-10 text-white lg:px-8 lg:py-14">
+      <div className="mx-auto max-w-[900px]">
+        <div className="flex items-center justify-between">
+          <h1 className="text-[34px] font-bold tracking-[-0.02em]">User Detail</h1>
+          <Link
+            href="/admin/users"
+            className="rounded-lg bg-main-1 px-5 py-2.5 text-sm font-semibold"
+          >
+            Back to Users
+          </Link>
+        </div>
+
+        <div className="mt-2 text-sm text-gray-4">Connected to `/api/admin/users/{'{loginId}'}`.</div>
+
+        {isLoading && (
+          <div className="mt-6 rounded-2xl border border-[#3a3d45] bg-[#2d3037] px-4 py-10 text-center text-gray-3">
+            Loading user detail...
+          </div>
+        )}
+
+        {!isLoading && error && (
+          <div className="mt-6 rounded-2xl border border-[#3a3d45] bg-[#2d3037] px-4 py-10 text-center text-[#ff9ea8]">
+            {error}
+          </div>
+        )}
+
+        {!isLoading && !error && user && (
+          <div className="mt-6 overflow-hidden rounded-2xl border border-[#3a3d45] bg-[#2d3037]">
+            <dl>
+              <Row label="loginId" value={user.loginId} />
+              <Row label="name" value={user.name} />
+              <Row label="department" value={user.department} />
+              <Row label="studentNo" value={user.studentNo} />
+              <Row label="grade" value={user.grade} />
+              <Row label="enrollmentStatus" value={user.enrollmentStatus} />
+              <Row label="birthDate" value={user.birthDate} />
+              <Row label="phone" value={user.phone} />
+              <Row label="withdrawalStatus" value={user.withdrawalStatus} />
+              <Row label="email" value={user.email} />
+              <Row label="generation" value={user.generation} />
+              <Row label="level" value={user.level} />
+              <Row label="track" value={user.track} />
+              <Row label="position" value={user.position} />
+            </dl>
+          </div>
+        )}
+      </div>
+    </section>
+  );
+}

--- a/features/admin/users/UsersDummyPage.tsx
+++ b/features/admin/users/UsersDummyPage.tsx
@@ -1,0 +1,263 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
+import { getAdminUserDetail, getAdminUsers } from "../api";
+import type { AdminUserDetail, AdminUserListItem } from "../type";
+
+function getInitials(name: string) {
+  return name
+    .split(" ")
+    .map((part) => part[0] ?? "")
+    .join("")
+    .slice(0, 2)
+    .toUpperCase();
+}
+
+function DetailRow({ label, value }: { label: string; value: string | number }) {
+  return (
+    <div className="grid grid-cols-[150px_1fr] gap-2 border-t border-[#3a3d45] px-4 py-3 text-sm">
+      <dt className="text-gray-4">{label}</dt>
+      <dd>{value}</dd>
+    </div>
+  );
+}
+
+export default function UsersDummyPage() {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState("");
+  const [users, setUsers] = useState<AdminUserListItem[]>([]);
+  const [totalCount, setTotalCount] = useState(0);
+
+  const [selectedLoginId, setSelectedLoginId] = useState<string | null>(null);
+  const [detailLoading, setDetailLoading] = useState(false);
+  const [detailError, setDetailError] = useState("");
+  const [detailCache, setDetailCache] = useState<Record<string, AdminUserDetail>>({});
+
+  useEffect(() => {
+    let mounted = true;
+    const load = async () => {
+      setIsLoading(true);
+      setError("");
+
+      try {
+        const response = await getAdminUsers();
+        if (!mounted) return;
+        setUsers(response.users);
+        setTotalCount(response.totalCount);
+      } catch {
+        if (!mounted) return;
+        setError("유저 목록을 불러오지 못했습니다. 로그인 상태와 관리자 권한을 확인해 주세요.");
+      } finally {
+        if (!mounted) return;
+        setIsLoading(false);
+      }
+    };
+
+    void load();
+    return () => {
+      mounted = false;
+    };
+  }, []);
+
+  useEffect(() => {
+    const loginIdFromQuery = searchParams.get("loginId");
+    if (!loginIdFromQuery) {
+      setSelectedLoginId(null);
+      setDetailError("");
+      return;
+    }
+    setSelectedLoginId(loginIdFromQuery);
+  }, [searchParams]);
+
+  useEffect(() => {
+    if (!selectedLoginId) return;
+    if (detailCache[selectedLoginId]) return;
+
+    let mounted = true;
+    const loadDetail = async () => {
+      setDetailLoading(true);
+      setDetailError("");
+      try {
+        const response = await getAdminUserDetail(selectedLoginId);
+        if (!mounted) return;
+        setDetailCache((prev) => ({
+          ...prev,
+          [selectedLoginId]: response.user,
+        }));
+      } catch {
+        if (!mounted) return;
+        setDetailError("유저 상세 정보를 불러오지 못했습니다.");
+      } finally {
+        if (!mounted) return;
+        setDetailLoading(false);
+      }
+    };
+
+    void loadDetail();
+    return () => {
+      mounted = false;
+    };
+  }, [selectedLoginId, detailCache]);
+
+  const safeCount = useMemo(() => {
+    if (totalCount > 0) return totalCount;
+    return users.length;
+  }, [totalCount, users.length]);
+
+  const selectedDetail = selectedLoginId ? detailCache[selectedLoginId] : null;
+
+  const handleSelect = (loginId: string) => {
+    const params = new URLSearchParams(searchParams.toString());
+    params.set("loginId", loginId);
+    router.replace(`/admin/users?${params.toString()}`, { scroll: false });
+  };
+
+  const handleCloseViewer = () => {
+    const params = new URLSearchParams(searchParams.toString());
+    params.delete("loginId");
+    const query = params.toString();
+    router.replace(query ? `/admin/users?${query}` : "/admin/users", {
+      scroll: false,
+    });
+  };
+
+  return (
+    <section className="bg-background px-4 py-10 text-white lg:px-8 lg:py-14">
+      <div className="mx-auto max-w-[1400px]">
+        <h1 className="text-[34px] font-bold tracking-[-0.02em]">Users</h1>
+        <p className="mt-2 text-sm text-gray-4">Connected to `/api/admin/users`.</p>
+
+        <div className={`mt-6 grid gap-4 ${selectedLoginId ? "lg:grid-cols-[1fr_1fr]" : ""}`}>
+          <div className="overflow-hidden rounded-2xl border border-[#3a3d45] bg-[#2d3037]">
+            <div className="overflow-x-auto">
+              <table className="min-w-full text-left text-sm">
+                <thead className="bg-[#26282d] text-gray-4">
+                  <tr>
+                    <th className="px-4 py-3 font-semibold">Profile</th>
+                    <th className="px-4 py-3 font-semibold">Login ID</th>
+                    <th className="px-4 py-3 font-semibold">Name</th>
+                    <th className="px-4 py-3 font-semibold">Department</th>
+                    <th className="px-4 py-3 font-semibold">Student No</th>
+                    <th className="px-4 py-3 font-semibold">Level</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {isLoading && (
+                    <tr className="border-t border-[#3a3d45]">
+                      <td colSpan={6} className="px-4 py-10 text-center text-gray-3">
+                        Loading users...
+                      </td>
+                    </tr>
+                  )}
+
+                  {!isLoading && error && (
+                    <tr className="border-t border-[#3a3d45]">
+                      <td colSpan={6} className="px-4 py-10 text-center text-[#ff9ea8]">
+                        {error}
+                      </td>
+                    </tr>
+                  )}
+
+                  {!isLoading && !error && users.length === 0 && (
+                    <tr className="border-t border-[#3a3d45]">
+                      <td colSpan={6} className="px-4 py-10 text-center text-gray-3">
+                        조회된 유저가 없습니다.
+                      </td>
+                    </tr>
+                  )}
+
+                  {!isLoading &&
+                    !error &&
+                    users.map((user) => (
+                      <tr
+                        key={user.loginId}
+                        className={`border-t border-[#3a3d45] transition-colors ${
+                          selectedLoginId === user.loginId ? "bg-[#3a404d]" : "hover:bg-[#333844]"
+                        }`}
+                      >
+                        <td className="px-4 py-3">
+                          <div
+                            className="flex h-10 w-10 items-center justify-center rounded-full bg-[#3b4a66] text-xs font-semibold tracking-wide"
+                            style={
+                              user.profileImageUrl
+                                ? {
+                                    backgroundImage: `url(${user.profileImageUrl})`,
+                                    backgroundSize: "cover",
+                                    backgroundPosition: "center",
+                                  }
+                                : undefined
+                            }
+                          >
+                            {!user.profileImageUrl ? getInitials(user.name) : ""}
+                          </div>
+                        </td>
+                        <td className="px-4 py-3">
+                          <button
+                            type="button"
+                            onClick={() => handleSelect(user.loginId)}
+                            className="underline decoration-[#7f889b] underline-offset-4"
+                          >
+                            {user.loginId}
+                          </button>
+                        </td>
+                        <td className="px-4 py-3">{user.name}</td>
+                        <td className="px-4 py-3">{user.department}</td>
+                        <td className="px-4 py-3">{user.studentNo}</td>
+                        <td className="px-4 py-3">{user.level}</td>
+                      </tr>
+                    ))}
+                </tbody>
+              </table>
+            </div>
+          </div>
+
+          {selectedLoginId && (
+            <div className="overflow-hidden rounded-2xl border border-[#3a3d45] bg-[#2d3037]">
+              <div className="flex items-center justify-between border-b border-[#3a3d45] px-4 py-3">
+                <h2 className="text-base font-semibold">User Detail Viewer</h2>
+                <button
+                  type="button"
+                  onClick={handleCloseViewer}
+                  className="rounded-md bg-[#454c5a] px-3 py-1.5 text-xs"
+                >
+                  닫기
+                </button>
+              </div>
+
+              {detailLoading && (
+                <p className="px-4 py-10 text-center text-sm text-gray-3">상세 불러오는 중...</p>
+              )}
+              {!detailLoading && detailError && (
+                <p className="px-4 py-10 text-center text-sm text-[#ff9ea8]">{detailError}</p>
+              )}
+
+              {!detailLoading && !detailError && selectedDetail && (
+                <dl>
+                  <DetailRow label="loginId" value={selectedDetail.loginId} />
+                  <DetailRow label="name" value={selectedDetail.name} />
+                  <DetailRow label="department" value={selectedDetail.department} />
+                  <DetailRow label="studentNo" value={selectedDetail.studentNo} />
+                  <DetailRow label="grade" value={selectedDetail.grade} />
+                  <DetailRow label="enrollmentStatus" value={selectedDetail.enrollmentStatus} />
+                  <DetailRow label="birthDate" value={selectedDetail.birthDate} />
+                  <DetailRow label="phone" value={selectedDetail.phone} />
+                  <DetailRow label="withdrawalStatus" value={selectedDetail.withdrawalStatus} />
+                  <DetailRow label="email" value={selectedDetail.email} />
+                  <DetailRow label="generation" value={selectedDetail.generation} />
+                  <DetailRow label="level" value={selectedDetail.level} />
+                  <DetailRow label="track" value={selectedDetail.track} />
+                  <DetailRow label="position" value={selectedDetail.position} />
+                </dl>
+              )}
+            </div>
+          )}
+        </div>
+
+        <p className="mt-4 text-xs text-gray-4">totalCount: {safeCount}</p>
+      </div>
+    </section>
+  );
+}


### PR DESCRIPTION
## 📎 관련 이슈
Closes #28


## 📝 작업 내용
- 관리자 유저 목록 페이지(`/admin/users`) 및 상세 페이지(`/admin/users/[loginId]`) 추가
- `/api/admin/users`, `/api/admin/users/{loginId}` 연동 로직 추가
- admin API/type에 users/recruitments 관련 타입 및 함수 확장
- 관리자 화면(레이아웃/엔트리 포함) 한글 깨짐 문구 복구
- 유저 목록에서 상세 진입 및 상세 데이터 표시 UI 구성

## 체크리스트
- [ ] 포메팅이 적용되었습니다.

## 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)

## 💬 비고